### PR TITLE
Fix app resource bundle crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.1 - 2026-05-22
+
+### Fixes
+
+- Fix packaged app icon loading by resolving the SwiftPM resource bundle from installed app locations and failing packaging when the bundle is missing or empty. Thanks @mbelinky.
+
 ## v0.2.0 - 2026-05-20
 
 ### Changes

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -18,8 +18,16 @@ mkdir -p "$MACOS_DIR" "$HELPERS_DIR" "$RESOURCES_DIR"
 
 cp ".build/release/CrawlBar" "$MACOS_DIR/CrawlBar"
 cp ".build/release/crawlbarctl" "$HELPERS_DIR/crawlbar"
-if [ -d ".build/release/CrawlBar_CrawlBar.bundle" ]; then
-  cp -R ".build/release/CrawlBar_CrawlBar.bundle" "$APP_DIR/CrawlBar_CrawlBar.bundle"
+RESOURCE_BUNDLE=".build/release/CrawlBar_CrawlBar.bundle"
+if [ -d "$RESOURCE_BUNDLE" ]; then
+  cp -R "$RESOURCE_BUNDLE" "$APP_DIR/CrawlBar_CrawlBar.bundle"
+  if ! find "$APP_DIR/CrawlBar_CrawlBar.bundle" -type f -print -quit | grep -q .; then
+    echo "SwiftPM resource bundle is empty: $RESOURCE_BUNDLE" >&2
+    exit 1
+  fi
+else
+  echo "missing SwiftPM resource bundle: $RESOURCE_BUNDLE" >&2
+  exit 1
 fi
 Scripts/generate_app_icon.swift "$RESOURCES_DIR/CrawlBar.icns"
 

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -47,7 +47,7 @@ cat > "$CONTENTS_DIR/Info.plist" <<'PLIST'
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.2.0</string>
+  <string>0.2.1</string>
   <key>CFBundleVersion</key>
   <string>1</string>
   <key>LSUIElement</key>

--- a/Sources/CrawlBar/BrandIcons.swift
+++ b/Sources/CrawlBar/BrandIcons.swift
@@ -144,12 +144,44 @@ enum CrawlBarIconFactory {
 
     private static func bundledIcon(for appID: CrawlAppID) -> NSImage? {
         guard let name = Self.bundledIconName(for: appID),
-              let url = Bundle.module.url(forResource: name, withExtension: "png", subdirectory: "BrandIcons")
-                ?? Bundle.module.url(forResource: name, withExtension: "png")
+              let url = Self.bundledIconURL(named: name)
         else {
             return nil
         }
         return NSImage(contentsOf: url)
+    }
+
+    private static func bundledIconURL(named name: String) -> URL? {
+        for bundle in Self.resourceBundleCandidates() {
+            if let url = bundle.url(forResource: name, withExtension: "png", subdirectory: "BrandIcons")
+                ?? bundle.url(forResource: name, withExtension: "png")
+            {
+                return url
+            }
+        }
+        return nil
+    }
+
+    private static func resourceBundleCandidates() -> [Bundle] {
+        let resourceBundleName = "CrawlBar_CrawlBar.bundle"
+        let candidateURLs = [
+            // SwiftPM executable bundles currently look beside the .app root.
+            Bundle.main.bundleURL.appendingPathComponent(resourceBundleName),
+            // Conventional app bundles keep resources under Contents/Resources.
+            Bundle.main.resourceURL?.appendingPathComponent(resourceBundleName),
+            // During local development, the executable and resource bundle share a build directory.
+            Bundle.main.executableURL?.deletingLastPathComponent().appendingPathComponent(resourceBundleName),
+        ].compactMap { $0 }
+
+        var seen = Set<String>()
+        var bundles: [Bundle] = []
+        for url in candidateURLs where seen.insert(url.path).inserted {
+            if let bundle = Bundle(url: url) {
+                bundles.append(bundle)
+            }
+        }
+        bundles.append(Bundle.main)
+        return bundles
     }
 
     private static func bundledIconName(for appID: CrawlAppID) -> String? {


### PR DESCRIPTION
## Summary

Fixes a macOS settings-window crash when CrawlBar's SwiftPM resource bundle is missing from the packaged app.

The crash report showed `Bundle.module` asserting from `CrawlBarIconFactory.bundledIcon(for:)` while rendering branded icons in Settings. This replaces the direct `Bundle.module` access with an optional bundle lookup that falls back to drawn icons, and makes `Scripts/package_app.sh` fail if the expected resource bundle is not packaged.

## Verification

- `swift build`
- `swift run crawlbar-selftest`
- `Scripts/package_app.sh`
- `test -f dist/CrawlBar.app/CrawlBar_CrawlBar.bundle/google.png && test -f dist/CrawlBar.app/CrawlBar_CrawlBar.bundle/granola.png && test -f dist/CrawlBar.app/CrawlBar_CrawlBar.bundle/x.png`
- `dist/CrawlBar.app/Contents/Helpers/crawlbar apps --json`
- `dist/CrawlBar.app/Contents/Helpers/crawlbar metadata --json`
- `dist/CrawlBar.app/Contents/Helpers/crawlbar config validate`
- `git diff --check`
