### PR TITLE
fix(app): normalize crawler PATH resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.2 - 2026-05-22
+
+### Fixes
+
+- Fix crawler discovery from the macOS app by normalizing PATH with common Homebrew, MacPorts, and user-local CLI locations before resolving or running crawler commands. Thanks @mbelinky.
+
 ## v0.2.1 - 2026-05-22
 
 ### Fixes

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -47,7 +47,7 @@ cat > "$CONTENTS_DIR/Info.plist" <<'PLIST'
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.2.1</string>
+  <string>0.2.2</string>
   <key>CFBundleVersion</key>
   <string>1</string>
   <key>LSUIElement</key>

--- a/Sources/CrawlBarCore/CommandRunner.swift
+++ b/Sources/CrawlBarCore/CommandRunner.swift
@@ -55,7 +55,7 @@ public struct CrawlExecutableResolver: @unchecked Sendable {
 
     public init(fileManager: FileManager = .default, environment: [String: String] = ProcessInfo.processInfo.environment) {
         self.fileManager = fileManager
-        self.environment = environment
+        self.environment = CrawlProcessEnvironment.normalized(environment)
     }
 
     public func resolve(_ requestedPathOrName: String) -> String? {
@@ -64,11 +64,7 @@ public struct CrawlExecutableResolver: @unchecked Sendable {
             return self.isExecutable(expanded) ? expanded : nil
         }
 
-        let pathEntries = (self.environment["PATH"] ?? "")
-            .split(separator: ":", omittingEmptySubsequences: true)
-            .map(String.init)
-
-        for entry in pathEntries {
+        for entry in CrawlProcessEnvironment.pathEntries(environment: self.environment) {
             let candidate = URL(fileURLWithPath: entry)
                 .appendingPathComponent(expanded)
                 .path
@@ -101,7 +97,7 @@ public struct CrawlCommandRunner: @unchecked Sendable {
         self.resolver = resolver
         self.redactor = redactor
         self.fileManager = fileManager
-        self.environment = environment
+        self.environment = CrawlProcessEnvironment.normalized(environment)
     }
 
     public func run(

--- a/Sources/CrawlBarCore/Installer.swift
+++ b/Sources/CrawlBarCore/Installer.swift
@@ -30,13 +30,16 @@ public struct CrawlInstaller: @unchecked Sendable {
 
     private let resolver: CrawlExecutableResolver
     private let redactor: CrawlCommandRedactor
+    private let environment: [String: String]
 
     public init(
         resolver: CrawlExecutableResolver = CrawlExecutableResolver(),
-        redactor: CrawlCommandRedactor = CrawlCommandRedactor())
+        redactor: CrawlCommandRedactor = CrawlCommandRedactor(),
+        environment: [String: String] = ProcessInfo.processInfo.environment)
     {
         self.resolver = resolver
         self.redactor = redactor
+        self.environment = CrawlProcessEnvironment.normalized(environment)
     }
 
     public func install(_ installation: CrawlAppInstallation, timeoutSeconds: TimeInterval = 900) throws -> CrawlCommandResult {
@@ -85,6 +88,7 @@ public struct CrawlInstaller: @unchecked Sendable {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executablePath)
         process.arguments = arguments
+        process.environment = self.environment
         process.standardOutput = stdoutHandle
         process.standardError = stderrHandle
 

--- a/Sources/CrawlBarCore/ProcessEnvironment.swift
+++ b/Sources/CrawlBarCore/ProcessEnvironment.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+public enum CrawlProcessEnvironment {
+    public static func normalized(_ environment: [String: String] = ProcessInfo.processInfo.environment) -> [String: String] {
+        var normalized = environment
+        normalized["PATH"] = self.path(environment: environment)
+        return normalized
+    }
+
+    public static func path(environment: [String: String] = ProcessInfo.processInfo.environment) -> String {
+        self.pathEntries(environment: environment).joined(separator: ":")
+    }
+
+    public static func pathEntries(environment: [String: String] = ProcessInfo.processInfo.environment) -> [String] {
+        var seen: Set<String> = []
+        var entries: [String] = []
+
+        for entry in (environment["PATH"] ?? "").split(separator: ":", omittingEmptySubsequences: true).map(String.init) {
+            self.append(entry, to: &entries, seen: &seen)
+        }
+
+        for entry in self.defaultExecutableSearchPaths(environment: environment) {
+            self.append(entry, to: &entries, seen: &seen)
+        }
+
+        return entries
+    }
+
+    private static func defaultExecutableSearchPaths(environment: [String: String]) -> [String] {
+        var paths = [
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+            "/usr/local/bin",
+            "/usr/local/sbin",
+            "/opt/local/bin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin",
+        ]
+
+        if let home = environment["HOME"]?.nilIfBlank ?? FileManager.default.homeDirectoryForCurrentUser.path.nilIfBlank {
+            paths.insert("\(home)/.local/bin", at: 0)
+            paths.insert("\(home)/bin", at: 1)
+        }
+
+        return paths
+    }
+
+    private static func append(_ path: String, to entries: inout [String], seen: inout Set<String>) {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, seen.insert(trimmed).inserted else { return }
+        entries.append(trimmed)
+    }
+}

--- a/Sources/CrawlBarSelfTest/SelfTest.swift
+++ b/Sources/CrawlBarSelfTest/SelfTest.swift
@@ -14,6 +14,7 @@ enum CrawlBarSelfTest {
         try Self.testActionFailuresPreserveStatusMetadata()
         try Self.testActionLogStoreReadsRecentResults()
         try Self.testQueryActionResolverSkipsSQLForPlainText()
+        try Self.testExecutableResolverUsesMacCliFallbackPaths()
         try Self.testConfigValuesReachCommandEnvironment()
         try Self.testGitcrawlCommandArgumentsInferRepository()
         try Self.testCommandTimeoutEscalates()
@@ -460,6 +461,47 @@ enum CrawlBarSelfTest {
             extraArguments: ["select count(*) from items"],
             timeoutSeconds: 5)
         try Self.expect(queryResult.stdout == "from-config|query select count(*) from items", "query arguments reach crawler commands")
+    }
+
+    private static func testExecutableResolverUsesMacCliFallbackPaths() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crawlbar-path-\(UUID().uuidString)", isDirectory: true)
+        let localBinURL = directory.appendingPathComponent(".local/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: localBinURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let scriptURL = localBinURL.appendingPathComponent("fallbackcrawl")
+        try Data("""
+        #!/bin/sh
+        printf '%s' "$PATH"
+        """.utf8).write(to: scriptURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+
+        let environment = [
+            "HOME": directory.path,
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+        ]
+        let resolver = CrawlExecutableResolver(environment: environment)
+        try Self.expect(
+            resolver.resolve("fallbackcrawl") == scriptURL.path,
+            "resolver checks user CLI fallback paths")
+
+        let manifest = CrawlAppManifest(
+            id: CrawlAppID(rawValue: "fallbackcrawl"),
+            displayName: "Fallback Crawl",
+            description: "A fallback PATH crawler",
+            binary: .init(name: "fallbackcrawl"),
+            branding: .init(symbolName: "terminal", accentColor: "#123456"),
+            paths: .init(),
+            commands: ["status": []],
+            capabilities: [.status])
+        let installation = CrawlAppInstallation(manifest: manifest, binaryPath: "fallbackcrawl")
+        let result = try CrawlCommandRunner(resolver: resolver, environment: environment)
+            .run(installation: installation, action: "status", timeoutSeconds: 5)
+
+        try Self.expect(
+            result.stdout.split(separator: ":").contains(Substring(localBinURL.path)),
+            "runner passes normalized fallback PATH to crawlers")
     }
 
     private static func testQueryActionResolverSkipsSQLForPlainText() throws {


### PR DESCRIPTION
## Summary
- Normalize CrawlBar's process PATH with common macOS CLI locations, including Homebrew, MacPorts, and user-local bins.
- Use the same normalized environment for crawler discovery, crawler command runs, and installer subprocesses.
- Add a self-test covering Finder-style minimal PATH discovery and subprocess PATH propagation.
- Add the v0.2.2 changelog entry and packaged app version bump.

## Root cause
Finder-launched macOS apps often inherit only `/usr/bin:/bin:/usr/sbin:/sbin`, so the SwiftUI app could not see crawlers installed in `/opt/homebrew/bin`, `/usr/local/bin`, or user-local bin directories even when the shell-launched CLI could.

## Validation
- `swift build`
- `swift run crawlbar-selftest`
- `swift run crawlbarctl apps --json`
- `env -i HOME="$HOME" PATH="/usr/bin:/bin:/usr/sbin:/sbin" swift run crawlbarctl apps --json`
- `swift run crawlbarctl metadata --json`
- `swift run crawlbarctl config validate`
- `Scripts/package_app.sh`
- `/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' dist/CrawlBar.app/Contents/Info.plist` -> `0.2.2`
