### PR TITLE
test: guard brand icon assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      - name: Brand icon compatibility
+        run: Scripts/check_brand_icons.sh
       - name: Build
         run: swift build
       - name: Selftest
@@ -22,6 +24,8 @@ jobs:
           swift run crawlbarctl config validate
       - name: Package app
         run: Scripts/package_app.sh
+      - name: Packaged brand icon compatibility
+        run: Scripts/check_brand_icons.sh dist/CrawlBar.app
       - name: Packaged CLI smoke
         run: |
           dist/CrawlBar.app/Contents/Helpers/crawlbar apps --json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add CrawlBar support for Cloudflare remote crawler archives, including built-in `remote status`, `remote archives`, and compressed SQLite `cloud publish` actions for `gitcrawl` and `discrawl`.
 - Surface Cloudflare D1/R2 archive status, remote archive metadata, and gzip chunked SQLite bundle details in normalized status JSON and the settings UI.
 - Bundle real macOS app icons for GitHub Desktop, Slack, Discord, Notion, WhatsApp, and Granola crawler rows.
+- Guard source and packaged brand icon assets in CI so crawler logos cannot regress silently. Thanks @vincentkoc.
 
 ## v0.2.2 - 2026-05-22
 

--- a/Scripts/check_brand_icons.sh
+++ b/Scripts/check_brand_icons.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+app_path="${1:-}"
+
+required_icon_hashes=(
+  "google.png:b4e8869eb52e2a8d9adfdb26e6643b61978b729a8a3a8b177815801da818c897"
+  "x.png:83e0da2c51442bf79fcc47f53b3ffb1253c043329fabf98500d32cc1ee9faee7"
+  "graincrawl.png:374540ba26515416a51812d6ac19b073e97e9b24bd7cd9538b5236a79cc333cd"
+  "granola.png:1cd3f0db4fe8a0d1ebdfa977f308df5079f55861e652242cf7e0129382c2748a"
+)
+
+sha256_file() {
+  local file_path="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file_path" | awk '{print $1}'
+    return
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file_path" | awk '{print $1}'
+    return
+  fi
+  echo "missing SHA-256 tool: expected shasum or sha256sum" >&2
+  exit 1
+}
+
+check_icon_dir() {
+  local icon_dir="$1"
+  local label="$2"
+
+  if [[ ! -d "$icon_dir" ]]; then
+    echo "missing $label BrandIcons directory: $icon_dir" >&2
+    return 1
+  fi
+
+  for icon_hash in "${required_icon_hashes[@]}"; do
+    local icon="${icon_hash%%:*}"
+    local expected_hash="${icon_hash#*:}"
+    local icon_path="$icon_dir/$icon"
+    if [[ ! -s "$icon_path" ]]; then
+      echo "missing or empty $label BrandIcons/$icon" >&2
+      return 1
+    fi
+    local actual_hash
+    actual_hash="$(sha256_file "$icon_path")"
+    if [[ "$actual_hash" != "$expected_hash" ]]; then
+      echo "unexpected $label BrandIcons/$icon SHA-256: $actual_hash" >&2
+      echo "expected: $expected_hash" >&2
+      return 1
+    fi
+  done
+}
+
+check_icon_dir "$root_dir/Sources/CrawlBar/Resources/BrandIcons" "source" || exit 1
+
+if [[ -n "$app_path" ]]; then
+  if [[ ! -d "$app_path" ]]; then
+    echo "missing app bundle: $app_path" >&2
+    exit 1
+  fi
+
+  packaged_icon_dirs=()
+  while IFS= read -r icon_path; do
+    packaged_icon_dirs+=("$(dirname "$icon_path")")
+  done < <(find "$app_path" -type f -name "google.png" | sort)
+  if [[ "${#packaged_icon_dirs[@]}" -eq 0 ]]; then
+    echo "missing packaged google.png under $app_path" >&2
+    exit 1
+  fi
+
+  for icon_dir in "${packaged_icon_dirs[@]}"; do
+    if check_icon_dir "$icon_dir" "packaged"; then
+      echo "brand icons ok: source and packaged app"
+      exit 0
+    fi
+  done
+
+  echo "packaged app is missing one or more required brand icons" >&2
+  printf 'searched directories:\n' >&2
+  printf '  %s\n' "${packaged_icon_dirs[@]}" >&2
+  exit 1
+fi
+
+echo "brand icons ok: source"


### PR DESCRIPTION
Summary

- Add a CI brand-icon compatibility guard for source and packaged CrawlBar assets.
- Pin Google, X, and legacy granola.png SHA-256 hashes so accidental replacement/removal fails.

Verification

- bash -n Scripts/check_brand_icons.sh
- Scripts/check_brand_icons.sh
- swift build
- swift run crawlbar-selftest
- swift run crawlbarctl apps --json
- swift run crawlbarctl metadata --json
- swift run crawlbarctl config validate
- Scripts/package_app.sh
- Scripts/check_brand_icons.sh dist/CrawlBar.app
- dist/CrawlBar.app/Contents/Helpers/crawlbar apps --json
- dist/CrawlBar.app/Contents/Helpers/crawlbar metadata --json
- dist/CrawlBar.app/Contents/Helpers/crawlbar config validate
- Negative packaged-granola smoke: fake app without granola.png failed as expected.
- Crabbox AWS run run_52b26facc829, lease cbx_8b449751f630, c7a.8xlarge: Scripts/check_brand_icons.sh passed.
