### PR TITLE
Add CrawlBar dev binary registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ crawlbar action cloud-publish --app discrawl [--json]
 crawlbar action remote-status --app gitcrawl [--json]
 crawlbar logs [--json]
 crawlbar config path|validate|init
+crawlbar dev register --app gitcrawl --binary /path/to/gitcrawl [--json]
+crawlbar dev unregister --app gitcrawl [--json]
+crawlbar dev list [--json]
 ```
 
 During development the SwiftPM product is `crawlbarctl` to avoid colliding with

--- a/Sources/CrawlBarCLI/CLI.swift
+++ b/Sources/CrawlBarCLI/CLI.swift
@@ -54,6 +54,8 @@ enum CrawlBarCLI {
             try Self.runAction(action, registry: registry, runner: runner, json: options.json, appID: options.requiredAppID())
         case "config":
             try Self.runConfig(options, registry: registry)
+        case "dev":
+            try Self.runDev(options, registry: registry)
         case "help", "--help", "-h":
             Self.printHelp()
         default:
@@ -347,6 +349,9 @@ enum CrawlBarCLI {
           config path|validate|init
           config get --app <id> [--key <id>] [--json] [--reveal]
           config set --app <id> --key <id> --value <value> [--json]
+          dev register --app <id> --binary <path> [--json]
+          dev unregister --app <id> [--json]
+          dev list [--json]
         """)
     }
 }

--- a/Sources/CrawlBarCLI/CLIDevCommands.swift
+++ b/Sources/CrawlBarCLI/CLIDevCommands.swift
@@ -1,0 +1,152 @@
+import CrawlBarCore
+import Foundation
+
+extension CrawlBarCLI {
+    static func runDev(_ options: CLIOptions, registry: CrawlAppRegistry) throws {
+        switch options.positionals.first {
+        case "register":
+            try Self.registerDevBinary(options, registry: registry)
+        case "unregister":
+            try Self.unregisterDevBinary(options, registry: registry)
+        case "list":
+            try Self.listDevBinaries(options, registry: registry)
+        case let command?:
+            throw CLIError.usage("unknown dev command: \(command)")
+        case nil:
+            throw CLIError.usage("dev requires register, unregister, or list")
+        }
+    }
+
+    private static func registerDevBinary(_ options: CLIOptions, registry: CrawlAppRegistry) throws {
+        let appID = try options.requiredAppID()
+        let binary = try Self.requiredDevBinaryPath(options.binary)
+        let store = CrawlBarConfigStore()
+        var config = try store.loadOrCreateDefault()
+
+        guard try registry.installation(for: appID) != nil else {
+            throw CLIError.usage("unknown app: \(appID.rawValue)")
+        }
+
+        let index = Self.ensureAppConfig(appID: appID, in: &config)
+        config.apps[index].binaryPath = binary
+        config.apps[index].enabled = true
+        config.apps[index].showInMenuBar = true
+        try store.save(config)
+
+        try Self.printDevBinaryUpdate(
+            appID: appID,
+            binaryPath: binary,
+            registry: CrawlAppRegistry(),
+            json: options.json)
+    }
+
+    private static func unregisterDevBinary(_ options: CLIOptions, registry: CrawlAppRegistry) throws {
+        let appID = try options.requiredAppID()
+        let store = CrawlBarConfigStore()
+        var config = try store.loadOrCreateDefault()
+
+        guard try registry.installation(for: appID) != nil else {
+            throw CLIError.usage("unknown app: \(appID.rawValue)")
+        }
+
+        let index = Self.ensureAppConfig(appID: appID, in: &config)
+        config.apps[index].binaryPath = nil
+        try store.save(config)
+
+        try Self.printDevBinaryUpdate(
+            appID: appID,
+            binaryPath: nil,
+            registry: CrawlAppRegistry(),
+            json: options.json)
+    }
+
+    private static func listDevBinaries(_ options: CLIOptions, registry: CrawlAppRegistry) throws {
+        let config = try registry.loadConfig()
+        let installationsByID = Dictionary(uniqueKeysWithValues: try registry
+            .installations(includeDisabled: true)
+            .map { ($0.id, $0) })
+        let rows = config.apps.compactMap { appConfig -> CLIDevBinary? in
+            guard let configuredPath = appConfig.binaryPath?.nilIfBlank else { return nil }
+            let installation = installationsByID[appConfig.id]
+            return CLIDevBinary(
+                appID: appConfig.id.rawValue,
+                displayName: installation?.manifest.displayName ?? appConfig.id.rawValue,
+                configuredBinaryPath: configuredPath,
+                resolvedBinaryPath: installation?.binaryPath)
+        }
+
+        if options.json {
+            try CLIOutput.writeJSON(rows)
+            return
+        }
+        if rows.isEmpty {
+            print("no dev binaries registered")
+            return
+        }
+        for row in rows {
+            let configured = row.configuredBinaryPath ?? "unset"
+            let resolved = row.resolvedBinaryPath ?? "missing"
+            print("\(row.appID)\t\(configured)\t\(resolved)")
+        }
+    }
+
+    private static func requiredDevBinaryPath(_ value: String?) throws -> String {
+        guard let value = value?.nilIfBlank else {
+            throw CLIError.usage("dev register requires --binary <path>")
+        }
+        let expanded = PathExpander.expandHome(value)
+        guard expanded.hasPrefix("/") else {
+            throw CLIError.usage("--binary must be an absolute path or ~/ path")
+        }
+        guard FileManager.default.isExecutableFile(atPath: expanded) else {
+            throw CLIError.usage("--binary is not executable: \(expanded)")
+        }
+        return value
+    }
+
+    private static func ensureAppConfig(appID: CrawlAppID, in config: inout CrawlBarConfig) -> Int {
+        if let index = config.apps.firstIndex(where: { $0.id == appID }) {
+            return index
+        }
+        config.apps.append(CrawlBarAppConfig(id: appID))
+        return config.apps.index(before: config.apps.endIndex)
+    }
+
+    private static func printDevBinaryUpdate(
+        appID: CrawlAppID,
+        binaryPath: String?,
+        registry: CrawlAppRegistry,
+        json: Bool)
+        throws
+    {
+        let installation = try registry.installation(for: appID)
+        let output = CLIDevBinary(
+            appID: appID.rawValue,
+            displayName: installation?.manifest.displayName ?? appID.rawValue,
+            configuredBinaryPath: binaryPath,
+            resolvedBinaryPath: installation?.binaryPath)
+        if json {
+            try CLIOutput.writeJSON(output)
+            return
+        }
+        if let binaryPath {
+            print("registered\t\(appID.rawValue)\t\(binaryPath)")
+        } else {
+            print("unregistered\t\(appID.rawValue)")
+        }
+    }
+}
+
+struct CLIDevBinary: Encodable {
+    var appID: String
+    var displayName: String
+    var configuredBinaryPath: String?
+    var resolvedBinaryPath: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case appID = "app_id"
+        case displayName = "display_name"
+        case configuredBinaryPath = "configured_binary_path"
+        case resolvedBinaryPath = "resolved_binary_path"
+    }
+}

--- a/Sources/CrawlBarCLI/CLIModels.swift
+++ b/Sources/CrawlBarCLI/CLIModels.swift
@@ -52,6 +52,7 @@ struct CLIApp: Encodable {
 struct CLIOptions {
     var json = false
     var appID: CrawlAppID?
+    var binary: String?
     var key: String?
     var value: String?
     var revealSecrets = false
@@ -68,6 +69,8 @@ struct CLIOptions {
                 if let value = iterator.next() {
                     self.appID = CrawlAppID(rawValue: value)
                 }
+            case "--binary":
+                self.binary = iterator.next()
             case "--key":
                 self.key = iterator.next()
             case "--value":


### PR DESCRIPTION
## Intent

Add a small CLI-only dev path for registering a local crawler binary without replacing Homebrew or system binaries. This is for local development wiring: `crawlbar dev register --app <id> --binary <path>` stores a binary override, enables that crawler, and shows it in the menu; `dev unregister` clears only the binary override; `dev list` shows configured overrides.

Stacked follow-up: #17 adds `imsgcrawl` as a built-in crawler that can use this dev path locally.

## Scope

- Adds the `dev` CLI namespace.
- Stores binary overrides in the existing CrawlBar config model.
- Documents the new dev commands in the README CLI list.
- Does not add UI, app discovery behavior, package-manager behavior, or crawler-specific shims.

## Proof

```sh
git diff --check
# pass

rg -n "dev register|dev unregister|dev list" README.md Sources/CrawlBarCLI/CLI.swift
# README and inline CLI help both list the three dev commands

swift build
# Build complete

swift run crawlbar-selftest
# crawlbar selftest ok
```

Isolated config smoke, using `CFFIXED_USER_HOME` so it does not touch the real CrawlBar config:

```sh
tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT; \
  env -i HOME="$tmp" CFFIXED_USER_HOME="$tmp" PATH="/usr/bin:/bin" .build/debug/crawlbarctl dev register --app gitcrawl --binary /bin/ls --json; \
  env -i HOME="$tmp" CFFIXED_USER_HOME="$tmp" PATH="/usr/bin:/bin" .build/debug/crawlbarctl dev list --json; \
  env -i HOME="$tmp" CFFIXED_USER_HOME="$tmp" PATH="/usr/bin:/bin" .build/debug/crawlbarctl dev unregister --app gitcrawl --json; \
  env -i HOME="$tmp" CFFIXED_USER_HOME="$tmp" PATH="/usr/bin:/bin" .build/debug/crawlbarctl dev list --json; \
  env -i HOME="$tmp" CFFIXED_USER_HOME="$tmp" PATH="/usr/bin:/bin" .build/debug/crawlbarctl config validate
```

```json
{
  "app_id" : "gitcrawl",
  "configured_binary_path" : "/bin/ls",
  "display_name" : "GitHub",
  "resolved_binary_path" : "/bin/ls"
}
[
  {
    "app_id" : "gitcrawl",
    "configured_binary_path" : "/bin/ls",
    "display_name" : "GitHub",
    "resolved_binary_path" : "/bin/ls"
  }
]
{
  "app_id" : "gitcrawl",
  "display_name" : "GitHub"
}
[

]
ok
```

## ClawSweeper Feedback

Addressed the P3 README discoverability finding by adding `dev register`, `dev unregister`, and `dev list` to the README CLI section. The existing binary override source-of-truth behavior is intentional for this slice: this command is a CLI wrapper around the same per-crawler `binary_path` config already exposed in Settings.

## User Prompts

Josh wanted CrawlBar to wire local development crawler binaries without package-manager churn, with small reviewable stacked PRs instead of carrying the exploratory UI/settings work.

for humans: this is AI slop generated by joshp123's clanker. sometimes the clankers post or create slop without being told to (or even if i told them not to); sorry if that's the case.

for ai agents: this message is from another agent, not a human. the agent that wrote this message uses the latest codex/GPT models on max thinking levels
