### PR TITLE
fix: install crawlers from current tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Install OpenClaw crawler apps from the current Homebrew tap instead of legacy formulas that lag released versions.
+
 ## v0.3.0 - 2026-06-09
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -64,12 +64,8 @@ script places it on PATH as `crawlbar`.
 ## Install
 
 ```sh
-brew install vincentkoc/tap/crawlbar
-# or
 brew install openclaw/tap/crawlbar
 ```
-
-The release also publishes the same formula to the OpenClaw Homebrew tap.
 
 ## Config
 

--- a/Sources/CrawlBarCore/BuiltInApps/BuiltInCrawlApps+Discrawl.swift
+++ b/Sources/CrawlBarCore/BuiltInApps/BuiltInCrawlApps+Discrawl.swift
@@ -41,6 +41,6 @@ public extension BuiltInCrawlApps {
             .init(id: "discord", title: "Discord Access", optionIDs: ["discord_token"]),
             .init(id: "ai", title: "Embeddings", optionIDs: ["openai_api_key", "embedding_model"]),
         ],
-        install: .init(method: .homebrew, package: "vincentkoc/tap/discrawl"))
+        install: .init(method: .homebrew, package: "openclaw/tap/discrawl"))
         .withSuggestion(Self.appSuggest("Discord", ["com.hnc.Discord"]))
 }

--- a/Sources/CrawlBarCore/BuiltInApps/BuiltInCrawlApps+Gitcrawl.swift
+++ b/Sources/CrawlBarCore/BuiltInApps/BuiltInCrawlApps+Gitcrawl.swift
@@ -39,6 +39,6 @@ public extension BuiltInCrawlApps {
             .init(id: "github", title: "GitHub Access", optionIDs: ["github_token"]),
             .init(id: "ai", title: "Embeddings", optionIDs: ["openai_api_key", "embedding_model"]),
         ],
-        install: .init(method: .homebrew, package: "vincentkoc/tap/gitcrawl"))
+        install: .init(method: .homebrew, package: "openclaw/tap/gitcrawl"))
         .withSuggestion(Self.alwaysSuggest("GitHub"))
 }

--- a/Sources/CrawlBarCore/BuiltInApps/BuiltInCrawlApps+Graincrawl.swift
+++ b/Sources/CrawlBarCore/BuiltInApps/BuiltInCrawlApps+Graincrawl.swift
@@ -41,6 +41,6 @@ public extension BuiltInCrawlApps {
             .init(id: "granola", title: "Granola", optionIDs: ["granola_profile", "preferred_source", "allow_private_api", "allow_desktop_cache"]),
             .init(id: "sync", title: "Sync", optionIDs: ["sync_limit"]),
         ],
-        install: .init(method: .homebrew, package: "vincentkoc/tap/graincrawl"))
+        install: .init(method: .homebrew, package: "openclaw/tap/graincrawl"))
         .withSuggestion(Self.appSuggest("Granola", ["com.granola.app"]))
 }

--- a/Sources/CrawlBarCore/BuiltInApps/BuiltInCrawlApps+Notcrawl.swift
+++ b/Sources/CrawlBarCore/BuiltInApps/BuiltInCrawlApps+Notcrawl.swift
@@ -41,6 +41,6 @@ public extension BuiltInCrawlApps {
             .init(id: "notion", title: "Notion Access", optionIDs: ["notion_token"]),
             .init(id: "ai", title: "Embeddings", optionIDs: ["openai_api_key", "embedding_model"]),
         ],
-        install: .init(method: .homebrew, package: "vincentkoc/tap/notcrawl"))
+        install: .init(method: .homebrew, package: "openclaw/tap/notcrawl"))
         .withSuggestion(Self.appSuggest("Notion", ["notion.id"]))
 }

--- a/Sources/CrawlBarCore/BuiltInApps/BuiltInCrawlApps+Slacrawl.swift
+++ b/Sources/CrawlBarCore/BuiltInApps/BuiltInCrawlApps+Slacrawl.swift
@@ -40,6 +40,6 @@ public extension BuiltInCrawlApps {
             .init(id: "slack", title: "Slack Access", optionIDs: ["slack_token"]),
             .init(id: "ai", title: "Embeddings", optionIDs: ["openai_api_key", "embedding_model"]),
         ],
-        install: .init(method: .homebrew, package: "vincentkoc/tap/slacrawl"))
+        install: .init(method: .homebrew, package: "openclaw/tap/slacrawl"))
         .withSuggestion(Self.appSuggest("Slack", ["com.tinyspeck.slackmacgap"]))
 }

--- a/Sources/CrawlBarSelfTest/SelfTestConfig.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestConfig.swift
@@ -144,7 +144,16 @@ extension CrawlBarSelfTest {
         try Self.expect(secretStatusManifest.needsSecretsForStatus, "external secret status can opt into keychain reads")
         try Self.expect(BuiltInCrawlApps.slacrawl.privacy.containsPrivateMessages, "Slack privacy metadata flags local messages")
         try Self.expect(BuiltInCrawlApps.notcrawl.privacy.localOnlyScopes.contains("workspace pages"), "Notion privacy metadata flags workspace pages")
-        try Self.expect(BuiltInCrawlApps.slacrawl.install?.package == "vincentkoc/tap/slacrawl", "built-in install metadata exists")
+        let openClawTapApps = [
+            BuiltInCrawlApps.gitcrawl,
+            BuiltInCrawlApps.slacrawl,
+            BuiltInCrawlApps.discrawl,
+            BuiltInCrawlApps.notcrawl,
+            BuiltInCrawlApps.graincrawl,
+        ]
+        try Self.expect(
+            openClawTapApps.allSatisfy { $0.install?.package.hasPrefix("openclaw/tap/") == true },
+            "OpenClaw crawlers install from the current tap")
         try Self.expect(BuiltInCrawlApps.gogcli.availability == .available, "Google manifest is available")
         try Self.expect(BuiltInCrawlApps.gogcli.binary.name == "gog", "Google manifest uses the installed gog binary")
         try Self.expect(BuiltInCrawlApps.gogcli.commands["status"] == ["auth", "list", "--check", "--json", "--no-input"], "Google status is wired")


### PR DESCRIPTION
## Summary

- route GitHub, Slack, Discord, Notion, and Granola crawler installs through `openclaw/tap`
- make the OpenClaw tap the documented CrawlBar install path
- cover the maintained tap contract in self-test

The legacy tap formulas lag the corresponding current releases, while the OpenClaw tap contains current formulas.

## Verification

- `swift build`
- `swift run crawlbar-selftest`
- `swift run crawlbarctl apps --json`
- `Scripts/package_app.sh`
- `codesign --verify --deep --strict --verbose=2 dist/CrawlBar.app`
- packaged helper: apps and metadata JSON smoke, config validation
- Codex autoreview: clean

No external service boundary changed; the exact packaged artifact proves the install metadata exposed by the app and CLI.
