### PR TITLE
ci: update checkout action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   swift:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Brand icon compatibility
         run: Scripts/check_brand_icons.sh
       - name: Build

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: [self-hosted, crabbox, openclaw, crawlbar, "${{ inputs.crabbox_runner_label }}"]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 


### PR DESCRIPTION
## Summary

- update both workflows from `actions/checkout@v6` to `actions/checkout@v7`

The current stable release keeps the Node 24 runtime already required by v6 and adds a safety guard for fork checkouts in privileged event types. CrawlBar uses only compatible `push`, `pull_request`, and `workflow_dispatch` paths.

Upstream: https://github.com/actions/checkout/releases/tag/v7.0.0

## Verification

- `actionlint`
- Codex autoreview: clean
- exact workflow execution required before merge

No application runtime or external service boundary changes.
