### PR TITLE
fix: align Photos crawler control contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-- Add Apple Photos as a coming-soon built-in crawler with read-only status, refresh, search, platform-native storage paths, and configurable library selection.
+- Add Apple Photos as a coming-soon built-in crawler with read-only status, initialization, search, and platform-native storage paths.
 
 ### Fixes
 

--- a/Sources/CrawlBarCore/BuiltInApps/BuiltInCrawlApps+Photoscrawl.swift
+++ b/Sources/CrawlBarCore/BuiltInApps/BuiltInCrawlApps+Photoscrawl.swift
@@ -20,10 +20,10 @@ public extension BuiltInCrawlApps {
         commands: [
             "metadata": ["metadata", "--json"],
             "status": ["status", "--json"],
-            "refresh": ["crawl", "--library", "{config:library_path}", "--json"],
+            "init": ["init", "--json"],
             "query": ["search", "--json", "--query"],
         ],
-        capabilities: [.status, .refresh, .search],
+        capabilities: [.status, .search],
         statusRequiresSecrets: false,
         privacy: .init(
             exportsSecrets: false,
@@ -33,16 +33,6 @@ public extension BuiltInCrawlApps {
                 "media-metadata",
                 "location-observations",
                 "local-model-observations",
-            ]),
-        configOptions: [
-            .init(
-                id: "library_path",
-                label: "Photos library",
-                help: "Photos Library package read by refresh; photoscrawl expands a leading ~/ path.",
-                defaultValue: "~/Pictures/Photos Library.photoslibrary"),
-        ],
-        configSections: [
-            .init(id: "photos", title: "Photos Library", optionIDs: ["library_path"]),
-        ])
+            ]))
         .withSuggestion(Self.appSuggest("Photos", ["com.apple.Photos"]))
 }

--- a/Sources/CrawlBarSelfTest/SelfTestConfig.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestConfig.swift
@@ -17,8 +17,14 @@ extension CrawlBarSelfTest {
         try Self.expect(config.appConfig(for: BuiltInCrawlApps.photoscrawlID)?.enabled == false, "coming-soon Photos crawler normalizes disabled")
         try Self.expect(BuiltInCrawlApps.photoscrawl.availability == .comingSoon, "Photos crawler remains coming soon without an installer")
         try Self.expect(
-            BuiltInCrawlApps.photoscrawl.commands["refresh"] == ["crawl", "--library", "{config:library_path}", "--json"],
-            "Photos refresh uses the configured library path")
+            BuiltInCrawlApps.photoscrawl.commands["init"] == ["init", "--json"],
+            "Photos initialization matches the crawler control contract")
+        try Self.expect(
+            BuiltInCrawlApps.photoscrawl.commands["query"] == ["search", "--json", "--query"],
+            "Photos search matches the crawler control contract")
+        try Self.expect(BuiltInCrawlApps.photoscrawl.commands["refresh"] == nil, "Photos does not advertise an unsupported refresh action")
+        try Self.expect(BuiltInCrawlApps.photoscrawl.capabilities == [.status, .search], "Photos capabilities match CrawlBar-supported crawler metadata")
+        try Self.expect(BuiltInCrawlApps.photoscrawl.configOptions.isEmpty, "Photos does not expose settings absent from crawler metadata")
         let oldConfig = CrawlBarConfig(
             version: 1,
             apps: [CrawlBarAppConfig(id: BuiltInCrawlApps.wacliID, enabled: false, showInMenuBar: false)]).normalized()


### PR DESCRIPTION
## Summary

- align the coming-soon Photos manifest with the current public photoscrawl control metadata
- replace the unadvertised refresh action with the upstream init action
- remove the unused library setting and lock the contract with self-test assertions
- correct the unreleased changelog description

Follow-up to #20. No release, version, tag, formula, or publish action is included.

## Contract proof

- `openclaw/photoscrawl@88aa4de67544aa05542b74a286037b48ac0fd6e4` metadata: identity, platform paths, privacy, status/init/query commands verified
- current photoscrawl help: crawl and search flags verified; no release or `openclaw/tap/photoscrawl` formula exists
- confidential-identifier scan: all categories PASS

## Validation

- `swift build`
- `swift run crawlbar-selftest`
- 11-app debug CLI config/metadata smoke
- packaged app build and strict codesign verification
- packaged helper config, 11-app, Photos metadata, and install-gate smoke
- structured autoreview: clean after addressing the accepted contract finding

`swift test` reports that this package has no XCTest target; repository contract tests live in `crawlbar-selftest`.
