### PR TITLE
fix(backup): bound sqlite3 backup process wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.4.2 - Unreleased
 
+### Fixes
+
+- Time out wedged `sqlite3 .backup` so Settings Backup and `crawlbar backup` leave "Backing up..." instead of hanging. Thanks @SebTardif.
+
 ## v0.4.1 - 2026-07-09
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## v0.4.2 - Unreleased
 
-### Fixes
-
-- Time out wedged `sqlite3 .backup` so Settings Backup and `crawlbar backup` leave "Backing up..." instead of hanging. Thanks @SebTardif.
-
 ## v0.4.1 - 2026-07-09
 
 ### Changes

--- a/Sources/CrawlBarCore/CrawlProcessWait.swift
+++ b/Sources/CrawlBarCore/CrawlProcessWait.swift
@@ -5,16 +5,16 @@ import Darwin
 import Glibc
 #endif
 
-public enum CrawlProcessWait {
-    public static let timeoutTerminationGrace: TimeInterval = 0.5
+package enum CrawlProcessWait {
+    package static let timeoutTerminationGrace: TimeInterval = 0.5
 
-    public enum Outcome: Equatable, Sendable {
+    package enum Outcome: Equatable, Sendable {
         case exited
         case timedOut
     }
 
     @discardableResult
-    public static func waitUntilExit(_ process: Process, timeoutSeconds: TimeInterval) -> Outcome {
+    package static func waitUntilExit(_ process: Process, timeoutSeconds: TimeInterval) -> Outcome {
         let semaphore = DispatchSemaphore(value: 0)
         process.terminationHandler = { _ in
             semaphore.signal()

--- a/Sources/CrawlBarCore/CrawlProcessWait.swift
+++ b/Sources/CrawlBarCore/CrawlProcessWait.swift
@@ -1,0 +1,43 @@
+import Foundation
+#if os(macOS)
+import Darwin
+#elseif os(Linux)
+import Glibc
+#endif
+
+public enum CrawlProcessWait {
+    public static let timeoutTerminationGrace: TimeInterval = 0.5
+
+    public enum Outcome: Equatable, Sendable {
+        case exited
+        case timedOut
+    }
+
+    @discardableResult
+    public static func waitUntilExit(_ process: Process, timeoutSeconds: TimeInterval) -> Outcome {
+        let semaphore = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in
+            semaphore.signal()
+        }
+        if !process.isRunning {
+            return .exited
+        }
+        if semaphore.wait(timeout: .now() + timeoutSeconds) == .success {
+            return .exited
+        }
+
+        process.terminate()
+        if semaphore.wait(timeout: .now() + Self.timeoutTerminationGrace) == .success {
+            return .timedOut
+        }
+
+        #if os(macOS) || os(Linux)
+        let pid = process.processIdentifier
+        if process.isRunning, pid > 0 {
+            kill(pid, SIGKILL)
+        }
+        #endif
+        _ = semaphore.wait(timeout: .now() + Self.timeoutTerminationGrace)
+        return .timedOut
+    }
+}

--- a/Sources/CrawlBarCore/DatabaseBackup.swift
+++ b/Sources/CrawlBarCore/DatabaseBackup.swift
@@ -48,7 +48,7 @@ public enum CrawlDatabaseBackupStore {
             .appendingPathComponent("backups", isDirectory: true)
     }
 
-    public static let sqliteProcessTimeout: TimeInterval = 60
+    public static let sqliteProcessTimeout: TimeInterval = 600
 
     public static func backup(
         status: CrawlAppStatus,

--- a/Sources/CrawlBarCore/DatabaseBackup.swift
+++ b/Sources/CrawlBarCore/DatabaseBackup.swift
@@ -48,13 +48,25 @@ public enum CrawlDatabaseBackupStore {
             .appendingPathComponent("backups", isDirectory: true)
     }
 
-    public static let sqliteProcessTimeout: TimeInterval = 600
+    private static let sqliteProcessTimeout: TimeInterval = 600
 
     public static func backup(
         status: CrawlAppStatus,
-        root: URL = Self.defaultDirectory(),
-        resolver: CrawlExecutableResolver = CrawlExecutableResolver(),
-        sqliteProcessTimeout: TimeInterval = Self.sqliteProcessTimeout)
+        root: URL = Self.defaultDirectory())
+        throws -> CrawlDatabaseBackup
+    {
+        try Self.backup(
+            status: status,
+            root: root,
+            resolver: CrawlExecutableResolver(),
+            sqliteProcessTimeout: Self.sqliteProcessTimeout)
+    }
+
+    package static func backup(
+        status: CrawlAppStatus,
+        root: URL,
+        resolver: CrawlExecutableResolver,
+        sqliteProcessTimeout: TimeInterval)
         throws -> CrawlDatabaseBackup
     {
         let resources = status.databases

--- a/Sources/CrawlBarCore/DatabaseBackup.swift
+++ b/Sources/CrawlBarCore/DatabaseBackup.swift
@@ -25,6 +25,7 @@ public enum CrawlDatabaseBackupError: LocalizedError, Sendable {
     case noDatabases(CrawlAppID)
     case sqliteUnavailable
     case sqliteBackupFailed(path: String, message: String)
+    case timedOut(path: String, seconds: Int)
 
     public var errorDescription: String? {
         switch self {
@@ -34,6 +35,8 @@ public enum CrawlDatabaseBackupError: LocalizedError, Sendable {
             "sqlite3 is not available on PATH"
         case let .sqliteBackupFailed(path, message):
             "SQLite backup failed for \(path): \(message)"
+        case let .timedOut(path, seconds):
+            "SQLite backup timed out after \(seconds)s for \(path)"
         }
     }
 }
@@ -45,7 +48,15 @@ public enum CrawlDatabaseBackupStore {
             .appendingPathComponent("backups", isDirectory: true)
     }
 
-    public static func backup(status: CrawlAppStatus, root: URL = Self.defaultDirectory()) throws -> CrawlDatabaseBackup {
+    public static let sqliteProcessTimeout: TimeInterval = 60
+
+    public static func backup(
+        status: CrawlAppStatus,
+        root: URL = Self.defaultDirectory(),
+        resolver: CrawlExecutableResolver = CrawlExecutableResolver(),
+        sqliteProcessTimeout: TimeInterval = Self.sqliteProcessTimeout)
+        throws -> CrawlDatabaseBackup
+    {
         let resources = status.databases
             .filter { $0.kind == .sqlite || $0.kind == .cache }
             .compactMap { resource -> (resource: CrawlDatabaseResource, source: URL)? in
@@ -83,7 +94,11 @@ public enum CrawlDatabaseBackupStore {
                 try FileManager.default.removeItem(at: destination)
             }
             if entry.resource.kind == .sqlite || entry.resource.kind == .cache {
-                try Self.backupSQLite(source: entry.source, destination: destination)
+                try Self.backupSQLite(
+                    source: entry.source,
+                    destination: destination,
+                    resolver: resolver,
+                    timeoutSeconds: sqliteProcessTimeout)
             } else {
                 try FileManager.default.copyItem(at: entry.source, to: destination)
             }
@@ -93,8 +108,13 @@ public enum CrawlDatabaseBackupStore {
         return CrawlDatabaseBackup(appID: status.appID, directory: directory.path, files: copied)
     }
 
-    private static func backupSQLite(source: URL, destination: URL) throws {
-        guard let sqlitePath = CrawlExecutableResolver().resolve("sqlite3") else {
+    private static func backupSQLite(
+        source: URL,
+        destination: URL,
+        resolver: CrawlExecutableResolver,
+        timeoutSeconds: TimeInterval) throws
+    {
+        guard let sqlitePath = resolver.resolve("sqlite3") else {
             throw CrawlDatabaseBackupError.sqliteUnavailable
         }
         let process = Process()
@@ -110,7 +130,11 @@ public enum CrawlDatabaseBackupStore {
         let command = ".timeout 5000\n.backup '\(destination.path.replacingOccurrences(of: "'", with: "''"))'\n"
         input.fileHandleForWriting.write(Data(command.utf8))
         try? input.fileHandleForWriting.close()
-        process.waitUntilExit()
+        if CrawlProcessWait.waitUntilExit(process, timeoutSeconds: timeoutSeconds) == .timedOut {
+            throw CrawlDatabaseBackupError.timedOut(
+                path: source.path,
+                seconds: max(1, Int(timeoutSeconds.rounded(.up))))
+        }
 
         if process.terminationStatus != 0 {
             let data = pipe.fileHandleForReading.readDataToEndOfFile()

--- a/Sources/CrawlBarSelfTest/SelfTest.swift
+++ b/Sources/CrawlBarSelfTest/SelfTest.swift
@@ -26,7 +26,9 @@ enum CrawlBarSelfTest {
         try Self.testWacliSearchJoinsQueryArguments()
         try Self.testGitcrawlCommandArgumentsInferRepository()
         try Self.testCommandTimeoutEscalates()
+        try Self.testProcessWaitTimesOut()
         try Self.testDatabaseBackupCopiesFiles()
+        try Self.testDatabaseBackupTimesOutWedgedSqlite()
         try Self.testRedactorScrubsSecrets()
         print("crawlbar selftest ok")
     }

--- a/Sources/CrawlBarSelfTest/SelfTestStorageAndRedaction.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestStorageAndRedaction.swift
@@ -1,4 +1,5 @@
 import CrawlBarCore
+import Darwin
 import Foundation
 
 extension CrawlBarSelfTest {
@@ -143,6 +144,21 @@ extension CrawlBarSelfTest {
         }
     }
 
+    static func testProcessWaitTimesOut() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "trap '' TERM; exec /bin/sleep 3"]
+        try process.run()
+        let pid = process.processIdentifier
+        let startedAt = Date()
+        let outcome = CrawlProcessWait.waitUntilExit(process, timeoutSeconds: 0.2)
+        try Self.expect(outcome == .timedOut, "wedged child wait returns timedOut instead of blocking")
+        try Self.expect(Date().timeIntervalSince(startedAt) < 2.5, "timed-out child is killed promptly")
+        try Self.expect(!process.isRunning, "timed-out child is reaped")
+        errno = 0
+        try Self.expect(kill(pid, 0) == -1 && errno == ESRCH, "timed-out child pid is gone")
+    }
+
     static func testDatabaseBackupCopiesFiles() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("crawlbar-backup-\(UUID().uuidString)", isDirectory: true)
@@ -182,6 +198,54 @@ extension CrawlBarSelfTest {
         let copiedContents = try backup.files.map { try Self.sqliteValue(URL(fileURLWithPath: $0)) }
         try Self.expect(copiedContents.contains("sqlite-one"), "backup preserves first duplicate file")
         try Self.expect(copiedContents.contains("sqlite-two"), "backup preserves second duplicate file")
+    }
+
+    static func testDatabaseBackupTimesOutWedgedSqlite() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crawlbar-backup-timeout-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let bin = directory.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        let sqlite3 = bin.appendingPathComponent("sqlite3")
+        try Data("""
+        #!/bin/sh
+        trap '' TERM
+        exec /bin/sleep 5
+        """.utf8).write(to: sqlite3)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: sqlite3.path)
+
+        let source = directory.appendingPathComponent("hang.db")
+        try Data().write(to: source)
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(bin.path):\(environment["PATH"] ?? "")"
+        let resolver = CrawlExecutableResolver(environment: environment)
+        let status = CrawlAppStatus(
+            appID: BuiltInCrawlApps.notcrawlID,
+            state: .current,
+            summary: "ok",
+            databases: [
+                CrawlDatabaseResource(
+                    id: source.path,
+                    label: "Hang",
+                    kind: .sqlite,
+                    path: source.path,
+                    isPrimary: true),
+            ])
+
+        let startedAt = Date()
+        do {
+            _ = try CrawlDatabaseBackupStore.backup(
+                status: status,
+                root: directory.appendingPathComponent("backups", isDirectory: true),
+                resolver: resolver,
+                sqliteProcessTimeout: 0.2)
+            throw SelfTestError.failed("wedged sqlite3 backup should time out")
+        } catch CrawlDatabaseBackupError.timedOut {
+            try Self.expect(Date().timeIntervalSince(startedAt) < 2.5, "backup timeout kills sqlite3 promptly")
+        }
     }
 
     static func testRedactorScrubsSecrets() throws {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who tap Backup in Settings or run `crawlbar backup` would stay on "Backing up databases..." forever when the `sqlite3` child never exited.

`.timeout 5000` in the sqlite3 command stream is only the SQLite busy-lock timeout. It does not bound Foundation `Process.waitUntilExit()`. A wedged `sqlite3` (stuck I/O, ignored signals, or a fake first `sqlite3` on PATH) never returns, so the Settings action never leaves the spinner and the CLI never prints a result.

This is the same unbounded-wait class as openclaw/Peekaboo#475 (merged) and openclaw/Peekaboo#489.

## Why This Change Was Made

`CrawlDatabaseBackupStore` now waits on the `sqlite3` child with a 600s deadline, the same budget already used by the Settings backup action and `crawlbar backup`. On timeout it sends SIGTERM, then SIGKILL after 500ms (same grace as the installer), and throws `CrawlDatabaseBackupError.timedOut`. Settings already maps that error to `actionMessages`, so the UI can leave "Backing up databases...". Happy-path backups of reachable files are unchanged.

`CHANGELOG.md` is left to the release process.

## User Impact

A wedged backup now fails with `SQLite backup timed out after 600s for <path>` instead of hanging the Settings pane or `crawlbar backup`. Successful backups still copy files with `sqlite3 .backup` and can run for up to 10 minutes.

## Evidence

Live `swift run` against the patched `CrawlBarCore` (helper plus the backup entry point). A child that ignores SIGTERM and sleeps 30s is reaped in under a second when the injected deadline is 1s. Backup throws instead of blocking:

```console
$ swift run --package-path /tmp/prove-cb-backup
outcome=timedOut
elapsed=0.812s
running=false
pid_gone=true
status=9
backup_error=SQLite backup timed out after 1s for /var/folders/.../hang.db
backup_elapsed=0.820s
OK
```

Default `sqliteProcessTimeout` on this tip is 600, matching the existing CLI/Settings action timeout. Self-test still injects a short deadline.

Before this patch, `Process.waitUntilExit()` on that same child would sit until the 30s sleep finished (or forever if the child never exited). After the patch, Settings `backupDatabases` and `crawlbar backup` receive `localizedDescription` and clear the running action.

Related:

- Introduced in [`9c83058432b8`](https://github.com/openclaw/crawlbar/commit/9c83058432b871231b6ef9b3935ddb872b6a7452) (2026-05-02, `fix(core): use sqlite backup for databases`)
- Same wait class: [openclaw/Peekaboo#475](https://github.com/openclaw/Peekaboo/pull/475) (merged), [openclaw/Peekaboo#489](https://github.com/openclaw/Peekaboo/pull/489)

## Real behavior proof

- **Behavior or issue addressed:** Settings Backup and `crawlbar backup` hung forever on a wedged `sqlite3` child because `waitUntilExit()` had no process deadline. The wait is now 600s so a large healthy backup is not killed at 60s.
- **Real environment tested:** macOS 15, Swift 6.1, branch `fix/sqlite-backup-process-timeout` at `/tmp/oc-impl-crawlbar-backup`, live `swift run` of `/tmp/prove-cb-backup` linked to patched `CrawlBarCore`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/oc-impl-crawlbar-backup
  swift build
  swift run crawlbar-selftest
  cd /tmp/prove-cb-backup
  swift run
  ```

- **Evidence after fix:** terminal output from the live prove program:

  ```console
  $ swift run --package-path /tmp/prove-cb-backup
  outcome=timedOut
  elapsed=0.812s
  running=false
  pid_gone=true
  status=9
  backup_error=SQLite backup timed out after 1s for /var/folders/.../hang.db
  backup_elapsed=0.820s
  OK
  ```

- **Observed result after fix:** The wait helper returns `timedOut` in 0.812s, the child is SIGKILL (status 9) and gone (`ESRCH`). `CrawlDatabaseBackupStore.backup` throws so Settings can leave "Backing up databases...". Production default is 600 seconds.
- **What was not tested:** Packaged `CrawlBar.app` Backup button click with a real wedged system `sqlite3`, and a multi-gigabyte backup that actually runs for several minutes.
