### PR TITLE
fix(security): keep crawler credentials out of logged state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   swift:
     runs-on: macos-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## v0.4.2 - Unreleased
 
-### Fixes
-
-- Keep crawler credentials out of app and CLI installation state while still passing them to the commands that need them.
-- Restrict the CI workflow token to read-only repository contents.
-
 ## v0.4.1 - 2026-07-09
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Keep crawler credentials out of app and CLI installation state while still passing them to the commands that need them.
+- Restrict the CI workflow token to read-only repository contents.
 
 ## v0.4.1 - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.4.2 - Unreleased
 
+### Fixes
+
+- Keep crawler credentials out of app and CLI installation state while still passing them to the commands that need them.
+
 ## v0.4.1 - 2026-07-09
 
 ### Changes

--- a/Sources/CrawlBar/Menu/MenuModel.swift
+++ b/Sources/CrawlBar/Menu/MenuModel.swift
@@ -93,7 +93,7 @@ final class CrawlBarMenuModel: NSObject {
         let statusService = self.statusService
         let appConfigs = self.appConfigs
         self.refreshTask = Task.detached {
-            let installations = (try? registry.installationsForStatus(includeDisabled: true)) ?? []
+            let installations = (try? registry.installations(includeDisabled: true)) ?? []
             let statusInstallations = CrawlBarCrawlerClassifier.statusInstallations(
                 installations,
                 appConfigsByID: appConfigs)
@@ -119,7 +119,10 @@ final class CrawlBarMenuModel: NSObject {
                         guard !Task.isCancelled else {
                             return CrawlAppStatus(appID: installation.id, state: .unknown, summary: "Refresh cancelled")
                         }
-                        return statusService.status(for: installation, timeoutSeconds: 5)
+                        return statusService.status(
+                            for: installation,
+                            configValues: registry.statusConfigValues(for: installation),
+                            timeoutSeconds: 5)
                     }
                 }
                 for await status in group {
@@ -162,12 +165,15 @@ final class CrawlBarMenuModel: NSObject {
         let logStore = self.logStore
         Task.detached {
             let updates = dueInstallations.map { installation -> CrawlActionStatusUpdate in
-                let actionInstallation = (try? registry.installation(for: installation.id, includeSecrets: true)) ?? installation
-                let statusInstallation = (try? registry.installationForStatus(for: installation.id)) ?? installation
+                let actionConfigValues = registry.executionConfigValues(for: installation)
+                let statusConfigValues = registry.statusConfigValues(for: installation)
 
                 func failureUpdate(_ failure: CrawlAppStatus) -> CrawlActionStatusUpdate {
                     CrawlActionStatusUpdate(
-                        status: statusService.status(for: statusInstallation, timeoutSeconds: 5),
+                        status: statusService.status(
+                            for: installation,
+                            configValues: statusConfigValues,
+                            timeoutSeconds: 5),
                         actionFailure: failure)
                 }
 
@@ -175,7 +181,11 @@ final class CrawlBarMenuModel: NSObject {
                     let refreshAction = config.preferredRefreshAction ?? "refresh"
                     do {
                         CrawlBarLog.actions.notice("Running scheduled \(refreshAction, privacy: .public) for \(installation.id.rawValue, privacy: .public)")
-                        let result = try runner.run(installation: actionInstallation, action: refreshAction, timeoutSeconds: 600)
+                        let result = try runner.run(
+                            installation: installation,
+                            configValues: actionConfigValues,
+                            action: refreshAction,
+                            timeoutSeconds: 600)
                         _ = try? logStore.save(result)
                         if !result.succeeded {
                             CrawlBarLog.actions.error(
@@ -194,7 +204,11 @@ final class CrawlBarMenuModel: NSObject {
                         let shareAction = config.preferredShareAction ?? "publish"
                         do {
                             CrawlBarLog.actions.notice("Running scheduled \(shareAction, privacy: .public) for \(installation.id.rawValue, privacy: .public)")
-                            let result = try runner.run(installation: actionInstallation, action: shareAction, timeoutSeconds: 600)
+                            let result = try runner.run(
+                                installation: installation,
+                                configValues: actionConfigValues,
+                                action: shareAction,
+                                timeoutSeconds: 600)
                             _ = try? logStore.save(result)
                             if !result.succeeded {
                                 CrawlBarLog.actions.error(
@@ -212,7 +226,10 @@ final class CrawlBarMenuModel: NSObject {
                     }
                 }
                 return CrawlActionStatusUpdate(
-                    status: statusService.status(for: statusInstallation, timeoutSeconds: 5),
+                    status: statusService.status(
+                        for: installation,
+                        configValues: statusConfigValues,
+                        timeoutSeconds: 5),
                     actionFailure: nil)
             }
             await MainActor.run {

--- a/Sources/CrawlBar/Settings/SettingsModelStatusActions.swift
+++ b/Sources/CrawlBar/Settings/SettingsModelStatusActions.swift
@@ -12,7 +12,7 @@ extension CrawlBarSettingsModel {
         let registry = self.registry
         let statusService = self.statusService
         self.refreshTask = Task.detached {
-            let installations = (try? registry.installationsForStatus(includeDisabled: true)) ?? []
+            let installations = (try? registry.installations(includeDisabled: true)) ?? []
             let appConfigsByID = Dictionary(uniqueKeysWithValues: appsForStatus.map { ($0.id, $0) })
             let statusInstallations = CrawlBarCrawlerClassifier.statusInstallations(
                 installations,
@@ -39,7 +39,10 @@ extension CrawlBarSettingsModel {
                         guard !Task.isCancelled else {
                             return CrawlAppStatus(appID: installation.id, state: .unknown, summary: "Refresh cancelled")
                         }
-                        return statusService.status(for: installation, timeoutSeconds: 5)
+                        return statusService.status(
+                            for: installation,
+                            configValues: registry.statusConfigValues(for: installation),
+                            timeoutSeconds: 5)
                     }
                 }
                 for await status in group {
@@ -68,12 +71,16 @@ extension CrawlBarSettingsModel {
         let logStore = self.logStore
         let registry = self.registry
         Task.detached {
-            let actionInstallation = (try? registry.installation(for: appID, includeSecrets: true)) ?? installation
+            let actionConfigValues = registry.executionConfigValues(for: installation)
             let message: String
             var actionError: CrawlAppStatus?
             do {
                 CrawlBarLog.actions.notice("Running \(action, privacy: .public) for \(appID.rawValue, privacy: .public) from settings")
-                let result = try runner.run(installation: actionInstallation, action: action, timeoutSeconds: 600)
+                let result = try runner.run(
+                    installation: installation,
+                    configValues: actionConfigValues,
+                    action: action,
+                    timeoutSeconds: 600)
                 _ = try? logStore.save(result)
                 message = result.exitCode == 0
                     ? "\(Self.actionTitle(action)) finished"
@@ -89,7 +96,10 @@ extension CrawlBarSettingsModel {
                 message = error.localizedDescription
                 actionError = Self.actionFailureStatus(appID: appID, action: action, message: error.localizedDescription)
             }
-            let refreshedStatus = statusService.status(for: actionInstallation, timeoutSeconds: 5)
+            let refreshedStatus = statusService.status(
+                for: installation,
+                configValues: registry.statusConfigValues(for: installation),
+                timeoutSeconds: 5)
             await MainActor.run {
                 let status = actionError.map {
                     Self.actionFailureStatus($0, refreshedStatus: refreshedStatus, currentStatus: self.statuses[appID])

--- a/Sources/CrawlBarCLI/CLI.swift
+++ b/Sources/CrawlBarCLI/CLI.swift
@@ -128,10 +128,13 @@ enum CrawlBarCLI {
         throws
     {
         let requestedID = options.appID
-        let installations = try registry.installationsForStatus(includeDisabled: true)
+        let installations = try registry.installations(includeDisabled: true)
             .filter { requestedID == nil || requestedID == CrawlAppID(rawValue: "all") || $0.id == requestedID }
         let statuses = installations.map { installation -> CrawlAppStatus in
-            statusService.status(for: installation, timeoutSeconds: 30)
+            statusService.status(
+                for: installation,
+                configValues: registry.statusConfigValues(for: installation),
+                timeoutSeconds: 30)
         }
 
         if options.json {
@@ -151,7 +154,7 @@ enum CrawlBarCLI {
         appID: CrawlAppID)
         throws
     {
-        guard let installation = try registry.installation(for: appID, includeSecrets: true) else {
+        guard let installation = try registry.installation(for: appID) else {
             throw CLIError.usage("unknown app: \(appID.rawValue)")
         }
         guard installation.enabled else {
@@ -160,7 +163,11 @@ enum CrawlBarCLI {
         guard installation.binaryPath != nil else {
             throw CLIError.usage("\(installation.manifest.binary.name) is not on PATH")
         }
-        let result = try runner.run(installation: installation, action: action, timeoutSeconds: 600)
+        let result = try runner.run(
+            installation: installation,
+            configValues: registry.executionConfigValues(for: installation),
+            action: action,
+            timeoutSeconds: 600)
         _ = try? CrawlActionLogStore().save(result)
         if json {
             try CLIOutput.writeJSON(result)
@@ -182,7 +189,7 @@ enum CrawlBarCLI {
         appID: CrawlAppID)
         throws
     {
-        guard let installation = try registry.installationForStatus(for: appID) else {
+        guard let installation = try registry.installation(for: appID) else {
             throw CLIError.usage("unknown app: \(appID.rawValue)")
         }
         guard installation.manifest.availability == .available else {
@@ -332,10 +339,13 @@ enum CrawlBarCLI {
         statusService: CrawlStatusService)
         throws -> CrawlAppStatus
     {
-        guard let installation = try registry.installationForStatus(for: appID) else {
+        guard let installation = try registry.installation(for: appID) else {
             throw CLIError.usage("unknown app: \(appID.rawValue)")
         }
-        return statusService.status(for: installation, timeoutSeconds: 30)
+        return statusService.status(
+            for: installation,
+            configValues: registry.statusConfigValues(for: installation),
+            timeoutSeconds: 30)
     }
 
     private static func printHelp() {

--- a/Sources/CrawlBarCore/ActionLogStore.swift
+++ b/Sources/CrawlBarCore/ActionLogStore.swift
@@ -16,15 +16,9 @@ public struct CrawlActionLogStore: @unchecked Sendable {
         if !self.fileManager.fileExists(atPath: self.directoryURL.path) {
             try self.fileManager.createDirectory(at: self.directoryURL, withIntermediateDirectories: true)
         }
-        let timestamp = ISO8601DateFormatter.crawlBarFormatter()
-            .string(from: result.finishedAt)
-            .replacingOccurrences(of: ":", with: "-")
-        let filename = [
-            Self.safeFilenameComponent(result.appID.rawValue, fallback: "app"),
-            Self.safeFilenameComponent(result.action, fallback: "action"),
-            timestamp,
-            UUID().uuidString,
-        ].joined(separator: "-") + ".json"
+        // Command results may derive from secret-bearing execution state.
+        // Opaque names keep result fields out of filesystem metadata.
+        let filename = UUID().uuidString + ".json"
         let url = self.directoryURL.appendingPathComponent(filename)
         let data = try CrawlCoding.makeJSONEncoder().encode(result)
         try data.write(to: url, options: [.atomic])
@@ -69,14 +63,4 @@ public struct CrawlActionLogStore: @unchecked Sendable {
         ((try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate) ?? .distantPast
     }
 
-    private static func safeFilenameComponent(_ value: String, fallback: String) -> String {
-        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
-        let scalars = value.unicodeScalars.map { scalar -> Character in
-            allowed.contains(scalar) ? Character(scalar) : "-"
-        }
-        let safe = String(scalars)
-            .split(separator: "-", omittingEmptySubsequences: true)
-            .joined(separator: "-")
-        return safe.nilIfBlank ?? fallback
-    }
 }

--- a/Sources/CrawlBarCore/CommandRunner.swift
+++ b/Sources/CrawlBarCore/CommandRunner.swift
@@ -27,20 +27,44 @@ public struct CrawlCommandRunner: @unchecked Sendable {
         timeoutSeconds: TimeInterval = 120)
         throws -> CrawlCommandResult
     {
-        guard var arguments = Self.commandOverride(for: installation, action: action)
+        try self.run(
+            installation: installation,
+            configValues: installation.configValues,
+            action: action,
+            extraArguments: extraArguments,
+            timeoutSeconds: timeoutSeconds)
+    }
+
+    package func run(
+        installation: CrawlAppInstallation,
+        configValues: [String: String],
+        action: String,
+        extraArguments: [String] = [],
+        timeoutSeconds: TimeInterval = 120)
+        throws -> CrawlCommandResult
+    {
+        guard var arguments = Self.commandOverride(
+            for: installation,
+            configValues: configValues,
+            action: action)
             ?? installation.manifest.commands[action]
         else {
             throw CrawlCommandRunnerError.commandUnavailable(appID: installation.id, action: action)
         }
-        arguments = try Self.interpolatedArguments(arguments, installation: installation)
+        arguments = try Self.interpolatedArguments(
+            arguments,
+            installation: installation,
+            configValues: configValues)
         arguments = Self.commandArguments(
             for: installation,
             action: action,
             commandArguments: arguments,
             extraArguments: extraArguments)
 
-        let executionKind = installation.manifest.executionKind(configValues: installation.configValues)
-        let effectiveBinaryName = Self.effectiveBinaryName(for: installation)
+        let executionKind = installation.manifest.executionKind(configValues: configValues)
+        let effectiveBinaryName = Self.effectiveBinaryName(
+            for: installation,
+            configValues: configValues)
         let executableName: String
         if executionKind == .ssh {
             executableName = "ssh"
@@ -61,7 +85,7 @@ public struct CrawlCommandRunner: @unchecked Sendable {
         }
         for option in installation.manifest.configOptions {
             guard let envName = option.envVar?.nilIfBlank,
-                  let value = installation.configValues[option.id]?.nilIfBlank
+                  let value = configValues[option.id]?.nilIfBlank
             else { continue }
             commandEnvironment[envName] = value
         }
@@ -72,16 +96,21 @@ public struct CrawlCommandRunner: @unchecked Sendable {
                 : effectiveBinaryName
             arguments = try Self.sshArguments(
                 for: installation,
+                configValues: configValues,
                 remoteArguments: arguments,
                 remoteBinaryOverride: remoteBinaryOverride)
         }
 
+        let maskedValues = installation.manifest.configOptions
+            .filter { $0.kind == .secret }
+            .compactMap { configValues[$0.id]?.nilIfBlank }
         return try self.runProcess(
             appID: installation.id,
             action: action,
             executablePath: executablePath,
             arguments: arguments,
             environment: commandEnvironment,
+            maskedValues: maskedValues,
             timeoutSeconds: timeoutSeconds)
     }
 }

--- a/Sources/CrawlBarCore/CrawlCommandRedactor.swift
+++ b/Sources/CrawlBarCore/CrawlCommandRedactor.swift
@@ -4,7 +4,17 @@ public struct CrawlCommandRedactor: Sendable {
     public init() {}
 
     public func redact(_ text: String) -> String {
+        self.redact(text, maskedValues: [])
+    }
+
+    package func redact(_ text: String, maskedValues: [String]) -> String {
         var redacted = text
+        // Opaque credentials may not match a token-shaped pattern, so mask injected values first.
+        let explicitValues = Set(maskedValues.compactMap(\.nilIfBlank))
+            .sorted { $0.count > $1.count }
+        for valueToMask in explicitValues {
+            redacted = redacted.replacingOccurrences(of: valueToMask, with: "[REDACTED]")
+        }
         let patterns: [(String, String)] = [
             (#"(?i)(Bearer[ \t]+)[^ \t\r\n"',}]+"#, "$1[REDACTED]"),
             (#"(?i)(api[_-]?key|token|secret|password|cookie|authorization)(["' \t:=]+)([^ \t\r\n"',}]+)"#, "$1$2[REDACTED]"),

--- a/Sources/CrawlBarCore/CrawlCommandRunnerArguments.swift
+++ b/Sources/CrawlBarCore/CrawlCommandRunnerArguments.swift
@@ -29,23 +29,32 @@ extension CrawlCommandRunner {
         return commandArguments + extraArguments
     }
 
-    static func interpolatedArguments(_ arguments: [String], installation: CrawlAppInstallation) throws -> [String] {
+    static func interpolatedArguments(
+        _ arguments: [String],
+        installation: CrawlAppInstallation,
+        configValues: [String: String])
+        throws -> [String]
+    {
         var result: [String] = []
         for argument in arguments {
             if let optionID = Self.exactConfigTokenID(argument),
-               Self.configValue(optionID, installation: installation) == nil,
+               Self.configValue(optionID, installation: installation, configValues: configValues) == nil,
                result.last == "--account"
             {
                 result.removeLast()
                 continue
             }
-            result.append(try Self.interpolatedArgument(argument, installation: installation))
+            result.append(try Self.interpolatedArgument(
+                argument,
+                installation: installation,
+                configValues: configValues))
         }
         return result
     }
 
     static func sshArguments(
         for installation: CrawlAppInstallation,
+        configValues: [String: String],
         remoteArguments: [String],
         remoteBinaryOverride: String? = nil)
         throws -> [String]
@@ -54,7 +63,11 @@ extension CrawlCommandRunner {
             return remoteArguments
         }
         let targetOptionID = execution.targetConfigID?.nilIfBlank ?? "remote_target"
-        guard let target = Self.configValue(targetOptionID, installation: installation) else {
+        guard let target = Self.configValue(
+            targetOptionID,
+            installation: installation,
+            configValues: configValues)
+        else {
             throw CrawlCommandRunnerError.missingRequiredConfig(appID: installation.id, optionID: targetOptionID)
         }
         guard !target.hasPrefix("-"), !target.contains(where: { $0.isWhitespace }) else {
@@ -66,10 +79,13 @@ extension CrawlCommandRunner {
             ?? installation.manifest.binary.name
         var commandParts = [remoteBinary] + remoteArguments
         let envFile = execution.remoteEnvFileConfigID
-            .flatMap { Self.configValue($0, installation: installation) }
+            .flatMap { Self.configValue($0, installation: installation, configValues: configValues) }
         let userCommand = Self.remoteShellCommand(commandParts: commandParts, envFile: envFile)
         if let runAsOptionID = execution.runAsConfigID?.nilIfBlank,
-           let runAs = Self.configValue(runAsOptionID, installation: installation)
+           let runAs = Self.configValue(
+               runAsOptionID,
+               installation: installation,
+               configValues: configValues)
         {
             guard !runAs.hasPrefix("-"), !runAs.contains(where: { $0.isWhitespace }) else {
                 throw CrawlCommandRunnerError.invalidRemoteTarget(appID: installation.id, target: runAs)
@@ -83,9 +99,14 @@ extension CrawlCommandRunner {
         return ["--", target, commandParts.map(Self.shellQuoted).joined(separator: " ")]
     }
 
-    static func commandOverride(for installation: CrawlAppInstallation, action: String) -> [String]? {
+    static func commandOverride(
+        for installation: CrawlAppInstallation,
+        configValues: [String: String],
+        action: String)
+        -> [String]?
+    {
         guard installation.id == BuiltInCrawlApps.birdclawID,
-              Self.xAccessPath(for: installation) == "birdclaw"
+              Self.xAccessPath(for: installation, configValues: configValues) == "birdclaw"
         else { return nil }
         switch action {
         case "status", "doctor":
@@ -97,15 +118,26 @@ extension CrawlCommandRunner {
         }
     }
 
-    static func effectiveBinaryName(for installation: CrawlAppInstallation) -> String {
+    static func effectiveBinaryName(
+        for installation: CrawlAppInstallation,
+        configValues: [String: String])
+        -> String
+    {
         guard installation.id == BuiltInCrawlApps.birdclawID else {
             return installation.manifest.binary.name
         }
-        return Self.xAccessPath(for: installation) == "birdclaw" ? "birdclaw" : "bird"
+        return Self.xAccessPath(for: installation, configValues: configValues) == "birdclaw"
+            ? "birdclaw"
+            : "bird"
     }
 
-    static func configValue(_ optionID: String, installation: CrawlAppInstallation) -> String? {
-        if let value = installation.configValues[optionID]?.nilIfBlank {
+    static func configValue(
+        _ optionID: String,
+        installation: CrawlAppInstallation,
+        configValues: [String: String])
+        -> String?
+    {
+        if let value = configValues[optionID]?.nilIfBlank {
             return value
         }
         return installation.manifest.configOptions.first { $0.id == optionID }?.defaultValue?.nilIfBlank
@@ -117,12 +149,21 @@ extension CrawlCommandRunner {
         return optionID.isEmpty ? nil : optionID
     }
 
-    private static func interpolatedArgument(_ argument: String, installation: CrawlAppInstallation) throws -> String {
+    private static func interpolatedArgument(
+        _ argument: String,
+        installation: CrawlAppInstallation,
+        configValues: [String: String])
+        throws -> String
+    {
         var value = argument
         while let range = value.range(of: #"\{config:([A-Za-z0-9_.-]+)\}"#, options: .regularExpression) {
             let token = String(value[range])
             let optionID = String(token.dropFirst("{config:".count).dropLast())
-            guard let replacement = Self.configValue(optionID, installation: installation) else {
+            guard let replacement = Self.configValue(
+                optionID,
+                installation: installation,
+                configValues: configValues)
+            else {
                 throw CrawlCommandRunnerError.missingRequiredConfig(appID: installation.id, optionID: optionID)
             }
             value.replaceSubrange(range, with: replacement)
@@ -142,8 +183,15 @@ extension CrawlCommandRunner {
         "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 
-    private static func xAccessPath(for installation: CrawlAppInstallation) -> String {
-        (Self.configValue("access_path", installation: installation) ?? "bird")
+    private static func xAccessPath(
+        for installation: CrawlAppInstallation,
+        configValues: [String: String])
+        -> String
+    {
+        (Self.configValue(
+            "access_path",
+            installation: installation,
+            configValues: configValues) ?? "bird")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
     }

--- a/Sources/CrawlBarCore/CrawlCommandRunnerProcess.swift
+++ b/Sources/CrawlBarCore/CrawlCommandRunnerProcess.swift
@@ -12,6 +12,7 @@ extension CrawlCommandRunner {
         executablePath: String,
         arguments: [String],
         environment: [String: String],
+        maskedValues: [String],
         timeoutSeconds: TimeInterval)
         throws -> CrawlCommandResult
     {
@@ -73,8 +74,8 @@ extension CrawlCommandRunner {
             appID: appID,
             action: action,
             exitCode: process.terminationStatus,
-            stdout: self.redactor.redact(stdout),
-            stderr: self.redactor.redact(stderr),
+            stdout: self.redactor.redact(stdout, maskedValues: maskedValues),
+            stderr: self.redactor.redact(stderr, maskedValues: maskedValues),
             startedAt: startedAt,
             finishedAt: Date())
     }

--- a/Sources/CrawlBarCore/Registry.swift
+++ b/Sources/CrawlBarCore/Registry.swift
@@ -88,6 +88,30 @@ public struct CrawlAppRegistry: @unchecked Sendable {
         try self.installations(includeDisabled: false, includeSecrets: includeSecrets).filter { $0.binaryPath != nil }
     }
 
+    package func executionConfigValues(for installation: CrawlAppInstallation) -> [String: String] {
+        // Keep credentials separate from installation metadata so UI and log identities stay secret-free.
+        let appConfig = CrawlBarAppConfig(
+            id: installation.id,
+            enabled: installation.enabled,
+            configPath: installation.configPathOverride,
+            configValues: installation.configValues)
+        let nativeConfig = self.appConfigWithNativeValues(
+            appConfig,
+            manifest: installation.manifest,
+            includeSecrets: true)
+        return self.configStore
+            .appConfigWithSecrets(nativeConfig, manifest: installation.manifest)
+            .configValues
+    }
+
+    package func statusConfigValues(for installation: CrawlAppInstallation) -> [String: String] {
+        guard installation.enabled,
+              installation.binaryPath != nil,
+              installation.manifest.needsSecretsForStatus
+        else { return installation.configValues }
+        return self.executionConfigValues(for: installation)
+    }
+
     public func appConfigWithNativeValues(
         _ appConfig: CrawlBarAppConfig,
         manifest: CrawlAppManifest,
@@ -103,21 +127,11 @@ public struct CrawlAppRegistry: @unchecked Sendable {
     }
 
     private func installationWithSecrets(_ installation: CrawlAppInstallation) -> CrawlAppInstallation {
-        let appConfig = CrawlBarAppConfig(
-            id: installation.id,
-            enabled: installation.enabled,
-            configPath: installation.configPathOverride,
-            configValues: installation.configValues)
-        let nativeConfig = self.appConfigWithNativeValues(
-            appConfig,
-            manifest: installation.manifest,
-            includeSecrets: true)
-        let secretConfig = self.configStore.appConfigWithSecrets(nativeConfig, manifest: installation.manifest)
         return CrawlAppInstallation(
             manifest: installation.manifest,
             binaryPath: installation.binaryPath,
             configPathOverride: installation.configPathOverride,
-            configValues: secretConfig.configValues,
+            configValues: self.executionConfigValues(for: installation),
             staleAfterSeconds: installation.staleAfterSeconds,
             enabled: installation.enabled)
     }

--- a/Sources/CrawlBarCore/StatusService.swift
+++ b/Sources/CrawlBarCore/StatusService.swift
@@ -13,14 +13,33 @@ public struct CrawlStatusService: @unchecked Sendable {
     }
 
     public func status(for installation: CrawlAppInstallation, timeoutSeconds: TimeInterval = 30) -> CrawlAppStatus {
+        self.status(
+            for: installation,
+            configValues: installation.configValues,
+            timeoutSeconds: timeoutSeconds)
+    }
+
+    package func status(
+        for installation: CrawlAppInstallation,
+        configValues: [String: String],
+        timeoutSeconds: TimeInterval = 30)
+        -> CrawlAppStatus
+    {
         if let status = self.immediateStatus(for: installation) {
             return status
         }
         if installation.id == BuiltInCrawlApps.gogcliID {
-            return self.gogcliStatus(for: installation, timeoutSeconds: timeoutSeconds)
+            return self.gogcliStatus(
+                for: installation,
+                configValues: configValues,
+                timeoutSeconds: timeoutSeconds)
         }
         do {
-            let result = try self.runner.run(installation: installation, action: "status", timeoutSeconds: timeoutSeconds)
+            let result = try self.runner.run(
+                installation: installation,
+                configValues: configValues,
+                action: "status",
+                timeoutSeconds: timeoutSeconds)
             return self.mapper.status(
                 from: result,
                 manifest: installation.manifest,
@@ -50,9 +69,18 @@ public struct CrawlStatusService: @unchecked Sendable {
         return GitcrawlStatusSnapshot.status(for: installation)
     }
 
-    private func gogcliStatus(for installation: CrawlAppInstallation, timeoutSeconds: TimeInterval) -> CrawlAppStatus {
+    private func gogcliStatus(
+        for installation: CrawlAppInstallation,
+        configValues: [String: String],
+        timeoutSeconds: TimeInterval)
+        -> CrawlAppStatus
+    {
         do {
-            let statusResult = try self.runner.run(installation: installation, action: "status", timeoutSeconds: timeoutSeconds)
+            let statusResult = try self.runner.run(
+                installation: installation,
+                configValues: configValues,
+                action: "status",
+                timeoutSeconds: timeoutSeconds)
             let status = self.mapper.status(
                 from: statusResult,
                 manifest: installation.manifest,
@@ -60,7 +88,11 @@ public struct CrawlStatusService: @unchecked Sendable {
             if status.state == .current {
                 return status
             }
-            let doctorResult = try self.runner.run(installation: installation, action: "doctor", timeoutSeconds: timeoutSeconds)
+            let doctorResult = try self.runner.run(
+                installation: installation,
+                configValues: configValues,
+                action: "doctor",
+                timeoutSeconds: timeoutSeconds)
             return self.mapper.status(
                 from: doctorResult,
                 manifest: installation.manifest,

--- a/Sources/CrawlBarSelfTest/SelfTestCommandRunner.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestCommandRunner.swift
@@ -11,6 +11,10 @@ extension CrawlBarSelfTest {
         let scriptURL = directory.appendingPathComponent("print-env.sh")
         try Data("""
         #!/bin/sh
+        if [ "$1" = "secret" ]; then
+          printf '%s' "$CRAWLBAR_TEST_SECRET"
+          exit 0
+        fi
         if [ "$#" -gt 0 ]; then
           printf '%s|%s' "$CRAWLBAR_TEST_VALUE" "$*"
         else
@@ -26,10 +30,11 @@ extension CrawlBarSelfTest {
             binary: .init(name: scriptURL.path),
             branding: .init(symbolName: "terminal", accentColor: "#123456"),
             paths: .init(),
-            commands: ["status": [], "query": ["query"]],
+            commands: ["status": [], "query": ["query"], "secret": ["secret"]],
             capabilities: [.status],
             configOptions: [
                 .init(id: "test_value", label: "Test Value", envVar: "CRAWLBAR_TEST_VALUE"),
+                .init(id: "secret_value", label: "Secret Value", kind: .secret, envVar: "CRAWLBAR_TEST_SECRET"),
             ])
         let installation = CrawlAppInstallation(
             manifest: manifest,
@@ -37,6 +42,18 @@ extension CrawlBarSelfTest {
             configValues: ["test_value": "from-config"])
         let result = try CrawlCommandRunner().run(installation: installation, action: "status", timeoutSeconds: 5)
         try Self.expect(result.stdout == "from-config", "config values reach crawler command environment")
+        let secret = "opaque-value-\(UUID().uuidString)"
+        let secretResult = try CrawlCommandRunner().run(
+            installation: installation,
+            configValues: installation.configValues.merging(["secret_value": secret]) { _, explicit in explicit },
+            action: "secret",
+            timeoutSeconds: 5)
+        try Self.expect(installation.configValues["secret_value"] == nil, "installation state remains secret-free")
+        try Self.expect(secretResult.stdout == "[REDACTED]", "explicit command secrets redact from output")
+        let logStore = CrawlActionLogStore(directoryURL: directory.appendingPathComponent("logs"))
+        let logURL = try logStore.save(secretResult)
+        let persisted = try String(contentsOf: logURL, encoding: .utf8)
+        try Self.expect(!persisted.contains(secret), "explicit command secrets stay out of action logs")
         let queryResult = try CrawlCommandRunner().run(
             installation: installation,
             action: "query",

--- a/Sources/CrawlBarSelfTest/SelfTestConfig.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestConfig.swift
@@ -290,17 +290,18 @@ extension CrawlBarSelfTest {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
 
+        let secret = "opaque-native-\(UUID().uuidString)"
         let scriptURL = directory.appendingPathComponent("secret-status.sh")
         try Data("""
         #!/bin/sh
-        printf '{"state":"ok"}'
+        printf '%s' "$STATUS_SECRET_TOKEN"
         """.utf8).write(to: scriptURL)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
 
         let nativeConfigURL = directory.appendingPathComponent("status.toml")
         try Data("""
         [auth]
-        token = "from-native"
+        token = "\(secret)"
         """.utf8).write(to: nativeConfigURL)
 
         let manifest = CrawlAppManifest(
@@ -330,9 +331,18 @@ extension CrawlBarSelfTest {
         }
         let statusConfigValues = registry.statusConfigValues(for: plain)
         try Self.expect(plain.configValues["token"] == nil, "plain installation omits native secret")
-        try Self.expect(statusConfigValues["token"] == "from-native", "status execution config rehydrates native secret")
+        try Self.expect(statusConfigValues["token"] == secret, "status execution config rehydrates native secret")
         try Self.expect(
-            legacyStatus.configValues["token"] == "from-native",
+            legacyStatus.configValues["token"] == secret,
             "shipped status installation API preserves secret hydration")
+        let result = try CrawlCommandRunner().run(
+            installation: plain,
+            configValues: statusConfigValues,
+            action: "status",
+            timeoutSeconds: 5)
+        try Self.expect(result.stdout == "[REDACTED]", "registry-hydrated native secret redacts from command output")
+        let logURL = try CrawlActionLogStore(directoryURL: directory.appendingPathComponent("logs")).save(result)
+        let persisted = try String(contentsOf: logURL, encoding: .utf8)
+        try Self.expect(!persisted.contains(secret), "registry-hydrated native secret stays out of action logs")
     }
 }

--- a/Sources/CrawlBarSelfTest/SelfTestConfig.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestConfig.swift
@@ -324,11 +324,15 @@ extension CrawlBarSelfTest {
         let registry = CrawlAppRegistry(configStore: store)
 
         guard let plain = try registry.installation(for: manifest.id, includeSecrets: false),
-              let status = try registry.installationForStatus(for: manifest.id)
+              let legacyStatus = try registry.installationForStatus(for: manifest.id)
         else {
             throw SelfTestError.failed("status secret crawler loads")
         }
+        let statusConfigValues = registry.statusConfigValues(for: plain)
         try Self.expect(plain.configValues["token"] == nil, "plain installation omits native secret")
-        try Self.expect(status.configValues["token"] == "from-native", "status installation rehydrates native secret")
+        try Self.expect(statusConfigValues["token"] == "from-native", "status execution config rehydrates native secret")
+        try Self.expect(
+            legacyStatus.configValues["token"] == "from-native",
+            "shipped status installation API preserves secret hydration")
     }
 }

--- a/Sources/CrawlBarSelfTest/SelfTestStorageAndRedaction.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestStorageAndRedaction.swift
@@ -47,7 +47,9 @@ extension CrawlBarSelfTest {
         try Self.expect(
             unsafeURL.deletingLastPathComponent().standardizedFileURL == directory.standardizedFileURL,
             "unsafe action log identifiers stay inside the log directory")
-        try Self.expect(!unsafeURL.lastPathComponent.contains("/"), "unsafe action log identifiers are filename-safe")
+        try Self.expect(
+            !unsafeURL.lastPathComponent.contains("unsafe") && !unsafeURL.lastPathComponent.contains("refresh"),
+            "action log filenames do not expose command identifiers")
 
         let successfulJSONResult = CrawlCommandResult(
             appID: BuiltInCrawlApps.graincrawlID,


### PR DESCRIPTION
## What Problem This Solves

Fixes five CodeQL alerts first reported by default-setup run `32460549009` at `4938a5f87b36d7a2a3799299a1e216c4fdceacbb`:

- `swift/cleartext-logging`: `Sources/CrawlBarCLI/CLI.swift` at the install, backup, and folder output paths.
- `swift/cleartext-logging`: `Sources/CrawlBarCore/ActionLogStore.swift` at persisted action-log filenames/results.
- `actions/missing-workflow-permissions`: `.github/workflows/ci.yml`.

Secret-bearing config values were folded into `CrawlAppInstallation`, so otherwise-public identity, path, status, and result fields inherited secret dataflow into CLI and log sinks.

## Why This Change Was Made

The app, settings, and CLI now keep installation metadata secret-free and hydrate credentials into a separate execution-only dictionary at the registry boundary. The runner consumes that dictionary only while assembling command arguments and environment, masks the exact injected credential values before returning or persisting command output, and uses opaque action-log filenames so result fields never become filesystem metadata.

The shipped public installation APIs remain compatible, but internal status and action flows use the new split boundary. CI also declares the `contents: read` permission recommended by `actions/checkout@v7`.

## User Impact

Crawler status checks and actions still receive required credentials without retaining them in UI/CLI installation state. Opaque credentials echoed by a crawler are now redacted before CLI output or action-log persistence, and CI no longer inherits broader repository token permissions.

## Evidence

- `swift build`
- `swift run crawlbar-selftest`
- `swift run crawlbarctl apps --json`
- `swift run crawlbarctl metadata --json`
- `swift run crawlbarctl config validate`
- `actionlint .github/workflows/ci.yml`
- `Scripts/check_brand_icons.sh`
- `/bin/bash Scripts/package_app.sh`
- `Scripts/check_brand_icons.sh dist/CrawlBar.app`
- `codesign --verify --deep --strict --verbose=2 dist/CrawlBar.app`
- `dist/CrawlBar.app/Contents/Helpers/crawlbar config validate`
- `git diff --check origin/main...HEAD`

Regression proof loads an opaque credential from a native crawler config through `CrawlAppRegistry`, verifies the installation stays secret-free, delivers the credential to a subprocess, and confirms the exact bytes are absent from both the returned result and persisted action log.

Production delta: `+236/-78` (net `+158`), justified by the new credential ownership and logging security boundary. Test delta: `+39/-6` (net `+33`).
