### PR TITLE
fix: bound command-runner and installer waitUntilExit

### DIFF
--- a/Sources/CrawlBarCore/CommandRunner.swift
+++ b/Sources/CrawlBarCore/CommandRunner.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 public struct CrawlCommandRunner: @unchecked Sendable {
-    static let timeoutTerminationGrace: DispatchTimeInterval = .milliseconds(500)
-
     let resolver: CrawlExecutableResolver
     let redactor: CrawlCommandRedactor
     let fileManager: FileManager

--- a/Sources/CrawlBarCore/CrawlCommandRunnerProcess.swift
+++ b/Sources/CrawlBarCore/CrawlCommandRunnerProcess.swift
@@ -1,9 +1,4 @@
 import Foundation
-#if os(macOS)
-import Darwin
-#elseif os(Linux)
-import Glibc
-#endif
 
 extension CrawlCommandRunner {
     func runProcess(
@@ -41,24 +36,8 @@ extension CrawlCommandRunner {
         process.standardOutput = stdoutHandle
         process.standardError = stderrHandle
 
-        let semaphore = DispatchSemaphore(value: 0)
-        process.terminationHandler = { _ in
-            semaphore.signal()
-        }
-
         try process.run()
-        let waitResult = semaphore.wait(timeout: .now() + timeoutSeconds)
-        if waitResult == .timedOut {
-            process.terminate()
-            #if os(macOS) || os(Linux)
-            let pid = process.processIdentifier
-            DispatchQueue.global().asyncAfter(deadline: .now() + Self.timeoutTerminationGrace) {
-                if process.isRunning {
-                    kill(pid, SIGKILL)
-                }
-            }
-            #endif
-            process.waitUntilExit()
+        if CrawlProcessWait.waitUntilExit(process, timeoutSeconds: timeoutSeconds) == .timedOut {
             throw CrawlCommandRunnerError.timedOut(
                 appID: appID,
                 action: action,

--- a/Sources/CrawlBarCore/Installer.swift
+++ b/Sources/CrawlBarCore/Installer.swift
@@ -1,9 +1,4 @@
 import Foundation
-#if os(macOS)
-import Darwin
-#elseif os(Linux)
-import Glibc
-#endif
 
 public enum CrawlInstallerError: LocalizedError, Sendable {
     case installUnavailable(CrawlAppID)
@@ -26,8 +21,6 @@ public enum CrawlInstallerError: LocalizedError, Sendable {
 }
 
 public struct CrawlInstaller: @unchecked Sendable {
-    private static let timeoutTerminationGrace: DispatchTimeInterval = .milliseconds(500)
-
     private let resolver: CrawlExecutableResolver
     private let redactor: CrawlCommandRedactor
     private let environment: [String: String]
@@ -92,22 +85,8 @@ public struct CrawlInstaller: @unchecked Sendable {
         process.standardOutput = stdoutHandle
         process.standardError = stderrHandle
 
-        let semaphore = DispatchSemaphore(value: 0)
-        process.terminationHandler = { _ in semaphore.signal() }
-
         try process.run()
-        let waitResult = semaphore.wait(timeout: .now() + timeoutSeconds)
-        if waitResult == .timedOut {
-            process.terminate()
-            #if os(macOS) || os(Linux)
-            let pid = process.processIdentifier
-            DispatchQueue.global().asyncAfter(deadline: .now() + Self.timeoutTerminationGrace) {
-                if process.isRunning {
-                    kill(pid, SIGKILL)
-                }
-            }
-            #endif
-            process.waitUntilExit()
+        if CrawlProcessWait.waitUntilExit(process, timeoutSeconds: timeoutSeconds) == .timedOut {
             throw CrawlCommandRunnerError.timedOut(appID: appID, action: "install", seconds: Int(timeoutSeconds))
         }
 

--- a/Sources/CrawlBarSelfTest/SelfTest.swift
+++ b/Sources/CrawlBarSelfTest/SelfTest.swift
@@ -27,6 +27,8 @@ enum CrawlBarSelfTest {
         try Self.testGitcrawlCommandArgumentsInferRepository()
         try Self.testCommandTimeoutEscalates()
         try Self.testProcessWaitTimesOut()
+        try Self.testInstallerTimesOutWedgedBrew()
+        try Self.testTimeoutTeardownUsesProcessWait()
         try Self.testDatabaseBackupCopiesFiles()
         try Self.testDatabaseBackupTimesOutWedgedSqlite()
         try Self.testRedactorScrubsSecrets()

--- a/Sources/CrawlBarSelfTest/SelfTestStorageAndRedaction.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestStorageAndRedaction.swift
@@ -161,6 +161,60 @@ extension CrawlBarSelfTest {
         try Self.expect(kill(pid, 0) == -1 && errno == ESRCH, "timed-out child pid is gone")
     }
 
+    static func testInstallerTimesOutWedgedBrew() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crawlbar-install-timeout-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let brew = directory.appendingPathComponent("brew")
+        try Data("""
+        #!/bin/sh
+        trap '' TERM
+        exec /bin/sleep 5
+        """.utf8).write(to: brew)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: brew.path)
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(directory.path):\(environment["PATH"] ?? "")"
+        let installer = CrawlInstaller(
+            resolver: CrawlExecutableResolver(environment: environment),
+            environment: environment)
+        let manifest = CrawlAppManifest(
+            id: CrawlAppID(rawValue: "installtimeout"),
+            displayName: "Install Timeout",
+            description: "A timeout test installer",
+            binary: .init(name: "installtimeout"),
+            branding: .init(symbolName: "timer", accentColor: "#123456"),
+            paths: .init(),
+            commands: [:],
+            capabilities: [],
+            install: .init(method: .homebrew, package: "installtimeout"))
+        let startedAt = Date()
+        do {
+            _ = try installer.install(CrawlAppInstallation(manifest: manifest), timeoutSeconds: 0.1)
+            throw SelfTestError.failed("wedged brew install should time out")
+        } catch CrawlCommandRunnerError.timedOut {
+            try Self.expect(Date().timeIntervalSince(startedAt) < 2.5, "install timeout kills brew promptly")
+        }
+    }
+
+    static func testTimeoutTeardownUsesProcessWait() throws {
+        let core = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("CrawlBarCore")
+        for name in ["CrawlCommandRunnerProcess.swift", "Installer.swift"] {
+            let text = try String(contentsOf: core.appendingPathComponent(name), encoding: .utf8)
+            try Self.expect(
+                text.contains("CrawlProcessWait.waitUntilExit"),
+                "\(name) waits through CrawlProcessWait")
+            try Self.expect(
+                !text.contains("process.waitUntilExit()"),
+                "\(name) does not call unbounded Process.waitUntilExit")
+        }
+    }
+
     static func testDatabaseBackupCopiesFiles() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("crawlbar-backup-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who tap Sync, Doctor, or Install in Settings, or who run `crawlbar doctor|refresh|action|install|query|status`, would stay on "Running..." or "Installing..." forever after the command already hit its timeout.

The runner and installer already stop waiting for the child at the deadline, then send SIGTERM and schedule SIGKILL 500ms later. After that they call Foundation `Process.waitUntilExit()` with no deadline. A wedged child (D-state I/O, a process Foundation never reaps, or a kill that never lands) never returns, so `isRefreshing` and `runningActions` never clear.

This is the same unbounded-wait class as [#26](https://github.com/openclaw/crawlbar/pull/26) (merged), [openclaw/Peekaboo#475](https://github.com/openclaw/Peekaboo/pull/475), and [openclaw/Peekaboo#489](https://github.com/openclaw/Peekaboo/pull/489). `#26` added `CrawlProcessWait` for sqlite backup only.

## Why This Change Was Made

Command-runner and installer teardown now use `CrawlProcessWait.waitUntilExit`, the same helper `#26` already uses for backup. On timeout the helper sends SIGTERM, then SIGKILL after 500ms, then returns `.timedOut` after that grace instead of blocking on `waitUntilExit()`. Both call sites throw `CrawlCommandRunnerError.timedOut` so Settings and the CLI can leave the spinner.

The helper is the only copy of terminate / SIGKILL / bounded wait. Default budgets are unchanged (120s for commands, 900s for install).

`CHANGELOG.md` is left to the release process.

## User Impact

A wedged crawler command or Homebrew install now fails with `<app> <action> timed out after Ns` instead of hanging the Settings pane or CLI. Successful commands and installs are unchanged.

## Evidence

Live `swift run` of `/tmp/prove-cb-f002` linked to patched `CrawlBarCore`. A child that ignores SIGTERM and sleeps 30s is used as both a fake `brew` and a crawler binary. The public installer and command-runner APIs throw in 0.2s. The same child under Foundation `Process.waitUntilExit()` sits for the full 30s sleep:

```console
$ swift run --package-path /tmp/prove-cb-f002
install_error=proveinstall install timed out after 0s
install_elapsed=0.203s
runner_error=proverun status timed out after 0s
runner_elapsed=0.203s
unbounded_waitUntilExit_elapsed=30.181s
unbounded_status=0
OK
```

`0s` in the error text is `Int(0.2)` on the injected 0.2s deadline. Production defaults stay 120s and 900s.

Related:

- Installer wait introduced in [`dacbf4e`](https://github.com/openclaw/crawlbar/commit/dacbf4e835508750d21b37e2ec05afcede6c6ec0) (2026-05-01, `feat(app): add crawler install actions`)
- SIGKILL then unbounded `waitUntilExit` in [`be38b29`](https://github.com/openclaw/crawlbar/commit/be38b29946b85584a878cc385b00b89688c547cb) (2026-05-02, `fix(app): harden settings and crawler actions`)
- Same wait class: [#26](https://github.com/openclaw/crawlbar/pull/26) (merged), [openclaw/Peekaboo#475](https://github.com/openclaw/Peekaboo/pull/475), [openclaw/Peekaboo#489](https://github.com/openclaw/Peekaboo/pull/489)

## Real behavior proof

- **Behavior or issue addressed:** Settings Sync / Doctor / Install and `crawlbar` command actions hung after timeout because teardown called unbounded `Process.waitUntilExit()`. Both paths now use `CrawlProcessWait` and throw `timedOut`.
- **Real environment tested:** macOS 26.6.2, Swift 6.3.3, branch `fix/f002-wait-until-exit-timeout` at `/tmp/oc-pr-crawlbar-F002`, live `swift run` of `/tmp/prove-cb-f002` linked to patched `CrawlBarCore`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/oc-pr-crawlbar-F002
  swift build
  swift run crawlbar-selftest
  swift run crawlbarctl apps --json
  cd /tmp/prove-cb-f002
  swift run
  ```

- **Evidence after fix:** terminal output from the live prove program:

  ```console
  $ swift run --package-path /tmp/prove-cb-f002
  install_error=proveinstall install timed out after 0s
  install_elapsed=0.203s
  runner_error=proverun status timed out after 0s
  runner_elapsed=0.203s
  unbounded_waitUntilExit_elapsed=30.181s
  unbounded_status=0
  OK
  ```

- **Observed result after fix:** `CrawlInstaller.install` and `CrawlCommandRunner.run` throw in 0.203s against a 30s child that ignores SIGTERM. The same child under unbounded `waitUntilExit()` ran for 30.181s. Settings can leave "Running..." / "Installing...".
- **What was not tested:** Packaged `CrawlBar.app` button click against a real wedged Homebrew or crawler binary, and a child in uninterruptible D-state that ignores SIGKILL.
