### PR TITLE
fix: keep backups archive-only and coordinate crawler actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Apply both share consent settings to manual sync publication and discard superseded action status updates.
 - Allow Settings sync to publish with unchanged native configuration, while stopping automatic publication when consent or nonsecret configuration changes or the main config is missing or invalid.
 - Re-read the main config before automatic publication so external consent, destination or malformed-file changes cannot be hidden by a cached modification time.
+- Stop automatic publication and scheduled publication retries when native config-only values change or their selected local config becomes unreadable, even if saved Settings values mask the change.
 - Restore legacy data `updated_at` as a freshness fallback without treating status-generation time as fresh data.
 - Keep crawler credentials out of UI/CLI installation state and redact echoed credentials before command output or action-log persistence. Thanks @vincentkoc.
 - Bound crawler-command and Homebrew-install timeout teardown so actions return when process termination fails. Thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Allow Settings sync to publish with unchanged native configuration, while stopping automatic publication when consent or nonsecret configuration changes or the main config is missing or invalid.
 - Re-read the main config before automatic publication so external consent, destination or malformed-file changes cannot be hidden by a cached modification time.
 - Stop automatic publication and scheduled publication retries when native config-only values change or their selected local config becomes unreadable, even if saved Settings values mask the change.
+- Check the native configuration selected by the command environment before automatic publication; refuse an empty configuration-file selector without changing manually invoked commands.
 - Restore legacy data `updated_at` as a freshness fallback without treating status-generation time as fresh data.
 - Keep crawler credentials out of UI/CLI installation state and redact echoed credentials before command output or action-log persistence. Thanks @vincentkoc.
 - Bound crawler-command and Homebrew-install timeout teardown so actions return when process termination fails. Thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Preserve recursive configuration substitution while bounding cycles and expansion.
 - Coordinate manual and scheduled mutations per crawler, respect retry intervals after failed attempts, and retry failed publication without repeating successful sync.
 - Apply both share consent settings to manual sync publication and discard superseded action status updates.
+- Allow Settings sync to publish with unchanged native configuration, while stopping automatic publication when consent or nonsecret configuration changes or the main config is missing or invalid.
+- Restore legacy data `updated_at` as a freshness fallback without treating status-generation time as fresh data.
 - Keep crawler credentials out of UI/CLI installation state and redact echoed credentials before command output or action-log persistence. Thanks @vincentkoc.
 - Bound crawler-command and Homebrew-install timeout teardown so actions return when process termination fails. Thanks @SebTardif.
 - Bound SQLite backup process waits to 600 seconds so wedged backups return a timeout instead of hanging Settings or the CLI. Thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Coordinate manual and scheduled mutations per crawler, respect retry intervals after failed attempts, and retry failed publication without repeating successful sync.
 - Apply both share consent settings to manual sync publication and discard superseded action status updates.
 - Allow Settings sync to publish with unchanged native configuration, while stopping automatic publication when consent or nonsecret configuration changes or the main config is missing or invalid.
+- Re-read the main config before automatic publication so external consent, destination or malformed-file changes cannot be hidden by a cached modification time.
 - Restore legacy data `updated_at` as a freshness fallback without treating status-generation time as fresh data.
 - Keep crawler credentials out of UI/CLI installation state and redact echoed credentials before command output or action-log persistence. Thanks @vincentkoc.
 - Bound crawler-command and Homebrew-install timeout teardown so actions return when process termination fails. Thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixes
 
+- Map iMessage archive paths without exposing the Messages source database to backup selection.
+- Keep status check timestamps separate from import/sync freshness and recognize missing external archives as requiring setup.
+- Preserve recursive configuration substitution while bounding cycles and expansion.
+- Coordinate manual and scheduled mutations per crawler, respect retry intervals after failed attempts, and retry failed publication without repeating successful sync.
+- Apply both share consent settings to manual sync publication and discard superseded action status updates.
 - Keep crawler credentials out of UI/CLI installation state and redact echoed credentials before command output or action-log persistence. Thanks @vincentkoc.
 - Bound crawler-command and Homebrew-install timeout teardown so actions return when process termination fails. Thanks @SebTardif.
 - Bound SQLite backup process waits to 600 seconds so wedged backups return a timeout instead of hanging Settings or the CLI. Thanks @SebTardif.

--- a/Sources/CrawlBar/Menu/MenuModel.swift
+++ b/Sources/CrawlBar/Menu/MenuModel.swift
@@ -165,7 +165,7 @@ final class CrawlBarMenuModel: NSObject {
             Task.detached {
                 let update = { () -> CrawlActionStatusUpdate? in
                     let actionConfigValues = registry.executionConfigValues(for: installation)
-                    let nativePublicationGuard = registry.nativePublicationGuard(for: installation, configValues: actionConfigValues)
+                    let nativePublicationGuard = registry.nativePublicationGuard(for: installation, configValues: actionConfigValues, runner: runner)
                     let statusConfigValues = registry.statusConfigValues(for: installation)
                     guard let config = configs[installation.id] else { return nil }
                     let outcome: CrawlActionOutcome

--- a/Sources/CrawlBar/Menu/MenuModel.swift
+++ b/Sources/CrawlBar/Menu/MenuModel.swift
@@ -4,6 +4,7 @@ import Foundation
 private struct CrawlActionStatusUpdate: Sendable {
     let status: CrawlAppStatus
     let actionFailure: CrawlAppStatus?
+    let generation: UInt64
 }
 
 @MainActor
@@ -20,7 +21,6 @@ final class CrawlBarMenuModel: NSObject {
     private var refreshTask: Task<Void, Never>?
     private var refreshGeneration = UUID()
     private var appConfigs: [CrawlAppID: CrawlBarAppConfig] = [:]
-    private var lastAutoSyncByAppID: [CrawlAppID: Date] = [:]
 
     override init() {
         let runner = CrawlCommandRunner()
@@ -145,108 +145,69 @@ final class CrawlBarMenuModel: NSObject {
     }
 
     func runDueAutoSync(onComplete: @escaping @MainActor () -> Void) {
-        guard !self.isRefreshing else { return }
         self.reloadInstallations()
         let now = Date()
         let dueInstallations = self.installations.filter { installation in
             guard let config = self.appConfigs[installation.id], config.enabled, config.autoRefreshEnabled else { return false }
             guard installation.enabled, installation.binaryPath != nil else { return false }
             guard let seconds = (config.refreshFrequency ?? self.refreshFrequency).seconds else { return false }
-            let last = self.lastAutoSyncByAppID[installation.id] ?? .distantPast
-            return now.timeIntervalSince(last) >= seconds
+            return CrawlActionCoordinator.shared.isDue(installation.id, interval: seconds, now: now)
         }
         guard !dueInstallations.isEmpty else { return }
 
-        self.isRefreshing = true
         let configs = self.appConfigs
+        let refreshFrequency = self.refreshFrequency
         let registry = self.registry
         let runner = self.runner
         let statusService = self.statusService
         let logStore = self.logStore
-        Task.detached {
-            let updates = dueInstallations.map { installation -> CrawlActionStatusUpdate in
-                let actionConfigValues = registry.executionConfigValues(for: installation)
-                let statusConfigValues = registry.statusConfigValues(for: installation)
-
-                func failureUpdate(_ failure: CrawlAppStatus) -> CrawlActionStatusUpdate {
-                    CrawlActionStatusUpdate(
+        for installation in dueInstallations {
+            Task.detached {
+                let update = { () -> CrawlActionStatusUpdate? in
+                    let actionConfigValues = registry.executionConfigValues(for: installation)
+                    let statusConfigValues = registry.statusConfigValues(for: installation)
+                    guard let config = configs[installation.id] else { return nil }
+                    let outcome: CrawlActionOutcome
+                    do {
+                        outcome = try CrawlActionCoordinator.shared.run(
+                            installation: installation,
+                            config: config,
+                            configValues: actionConfigValues,
+                            action: config.preferredRefreshAction ?? "refresh",
+                            scheduledInterval: (config.refreshFrequency ?? refreshFrequency).seconds,
+                            allowShare: {
+                                (try? registry.loadConfig().apps.first { $0.id == installation.id }) == config
+                            },
+                            execute: { action in
+                                try runner.run(
+                                    installation: installation, configValues: actionConfigValues,
+                                    action: action, timeoutSeconds: 600)
+                            })
+                    } catch CrawlActionCoordinatorError.busy, CrawlActionCoordinatorError.notDue {
+                        return nil
+                    } catch {
+                        CrawlBarLog.actions.error("Scheduled action could not start: \(error.localizedDescription, privacy: .public)")
+                        return nil
+                    }
+                    for result in outcome.results { _ = try? logStore.save(result) }
+                    return CrawlActionStatusUpdate(
                         status: statusService.status(
                             for: installation,
                             configValues: statusConfigValues,
                             timeoutSeconds: 5),
-                        actionFailure: failure)
-                }
-
-                if let config = configs[installation.id] {
-                    let refreshAction = config.preferredRefreshAction ?? "refresh"
-                    do {
-                        CrawlBarLog.actions.notice("Running scheduled \(refreshAction, privacy: .public) for \(installation.id.rawValue, privacy: .public)")
-                        let result = try runner.run(
-                            installation: installation,
-                            configValues: actionConfigValues,
-                            action: refreshAction,
-                            timeoutSeconds: 600)
-                        _ = try? logStore.save(result)
-                        if !result.succeeded {
-                            CrawlBarLog.actions.error(
-                                "Scheduled \(refreshAction, privacy: .public) for \(installation.id.rawValue, privacy: .public) failed with exit \(result.exitCode)")
-                            return failureUpdate(Self.actionFailureStatus(result))
-                        }
-                    } catch {
-                        CrawlBarLog.actions.error(
-                            "Scheduled \(refreshAction, privacy: .public) for \(installation.id.rawValue, privacy: .public) threw: \(error.localizedDescription, privacy: .public)")
-                        return failureUpdate(Self.actionFailureStatus(
-                            appID: installation.id,
-                            action: refreshAction,
-                            message: error.localizedDescription))
-                    }
-                    if config.shareEnabled, config.shareAfterRefresh {
-                        let shareAction = config.preferredShareAction ?? "publish"
-                        do {
-                            CrawlBarLog.actions.notice("Running scheduled \(shareAction, privacy: .public) for \(installation.id.rawValue, privacy: .public)")
-                            let result = try runner.run(
-                                installation: installation,
-                                configValues: actionConfigValues,
-                                action: shareAction,
-                                timeoutSeconds: 600)
-                            _ = try? logStore.save(result)
-                            if !result.succeeded {
-                                CrawlBarLog.actions.error(
-                                    "Scheduled \(shareAction, privacy: .public) for \(installation.id.rawValue, privacy: .public) failed with exit \(result.exitCode)")
-                                return failureUpdate(Self.actionFailureStatus(result))
-                            }
-                        } catch {
-                            CrawlBarLog.actions.error(
-                                "Scheduled \(shareAction, privacy: .public) for \(installation.id.rawValue, privacy: .public) threw: \(error.localizedDescription, privacy: .public)")
-                            return failureUpdate(Self.actionFailureStatus(
-                                appID: installation.id,
-                                action: shareAction,
-                                message: error.localizedDescription))
-                        }
-                    }
-                }
-                return CrawlActionStatusUpdate(
-                    status: statusService.status(
-                        for: installation,
-                        configValues: statusConfigValues,
-                        timeoutSeconds: 5),
-                    actionFailure: nil)
-            }
-            await MainActor.run {
-                var changedStatuses: [CrawlAppID: CrawlAppStatus] = [:]
-                for update in updates {
+                        actionFailure: outcome.failure,
+                        generation: outcome.generation)
+                }()
+                guard let update else { return }
+                await MainActor.run {
+                    guard CrawlActionCoordinator.shared.isCurrent(update.status.appID, generation: update.generation) else { return }
                     let status = update.actionFailure.map {
                         Self.actionFailureStatus($0, refreshedStatus: update.status, currentStatus: self.statuses[$0.appID])
                     } ?? update.status
                     self.statuses[status.appID] = status
-                    changedStatuses[status.appID] = status
-                    if update.actionFailure == nil, status.state != .error {
-                        self.lastAutoSyncByAppID[status.appID] = now
-                    }
+                    CrawlBarStateBroadcast.statusesDidChange([status.appID: status])
+                    onComplete()
                 }
-                CrawlBarStateBroadcast.statusesDidChange(changedStatuses)
-                self.isRefreshing = false
-                onComplete()
             }
         }
     }

--- a/Sources/CrawlBar/Menu/MenuModel.swift
+++ b/Sources/CrawlBar/Menu/MenuModel.swift
@@ -165,6 +165,7 @@ final class CrawlBarMenuModel: NSObject {
             Task.detached {
                 let update = { () -> CrawlActionStatusUpdate? in
                     let actionConfigValues = registry.executionConfigValues(for: installation)
+                    let nativePublicationGuard = registry.nativePublicationGuard(for: installation, configValues: actionConfigValues)
                     let statusConfigValues = registry.statusConfigValues(for: installation)
                     guard let config = configs[installation.id] else { return nil }
                     let outcome: CrawlActionOutcome
@@ -177,6 +178,7 @@ final class CrawlBarMenuModel: NSObject {
                             scheduledInterval: (config.refreshFrequency ?? refreshFrequency).seconds,
                             allowShare: {
                                 (try? registry.loadConfig().apps.first { $0.id == installation.id }) == config
+                                    && nativePublicationGuard()
                             },
                             execute: { action in
                                 try runner.run(

--- a/Sources/CrawlBar/Settings/SettingsModelStatusActions.swift
+++ b/Sources/CrawlBar/Settings/SettingsModelStatusActions.swift
@@ -73,7 +73,7 @@ extension CrawlBarSettingsModel {
         let registry = self.registry
         Task.detached {
             let actionConfigValues = registry.executionConfigValues(for: installation)
-            let nativePublicationGuard = registry.nativePublicationGuard(for: installation, configValues: actionConfigValues)
+                let nativePublicationGuard = registry.nativePublicationGuard(for: installation, configValues: actionConfigValues, runner: runner)
             let message: String
             var actionError: CrawlAppStatus?
             var generation: UInt64?

--- a/Sources/CrawlBar/Settings/SettingsModelStatusActions.swift
+++ b/Sources/CrawlBar/Settings/SettingsModelStatusActions.swift
@@ -83,7 +83,7 @@ extension CrawlBarSettingsModel {
                     config: config,
                     configValues: actionConfigValues,
                     action: action,
-                    allowShare: { (try? registry.loadConfig().apps.first { $0.id == appID }) == config },
+                    allowShare: { registry.matchesPersistedAppConfig(config, manifest: installation.manifest) },
                     execute: { next in
                         try runner.run(
                             installation: installation, configValues: actionConfigValues,

--- a/Sources/CrawlBar/Settings/SettingsModelStatusActions.swift
+++ b/Sources/CrawlBar/Settings/SettingsModelStatusActions.swift
@@ -63,7 +63,8 @@ extension CrawlBarSettingsModel {
     }
 
     func runAction(_ action: String, appID: CrawlAppID) {
-        guard let installation = self.installations[appID] else { return }
+        guard let installation = self.installations[appID], self.runningActions[appID] == nil else { return }
+        let config = self.apps.first { $0.id == appID } ?? CrawlBarAppConfig(id: appID)
         self.runningActions[appID] = action
         self.actionMessages[appID] = "Running \(Self.actionTitle(action))..."
         let runner = self.runner
@@ -74,22 +75,32 @@ extension CrawlBarSettingsModel {
             let actionConfigValues = registry.executionConfigValues(for: installation)
             let message: String
             var actionError: CrawlAppStatus?
+            var generation: UInt64?
             do {
                 CrawlBarLog.actions.notice("Running \(action, privacy: .public) for \(appID.rawValue, privacy: .public) from settings")
-                let result = try runner.run(
+                let outcome = try CrawlActionCoordinator.shared.run(
                     installation: installation,
+                    config: config,
                     configValues: actionConfigValues,
                     action: action,
-                    timeoutSeconds: 600)
-                _ = try? logStore.save(result)
-                message = result.exitCode == 0
+                    allowShare: { (try? registry.loadConfig().apps.first { $0.id == appID }) == config },
+                    execute: { next in
+                        try runner.run(
+                            installation: installation, configValues: actionConfigValues,
+                            action: next, timeoutSeconds: 600)
+                    })
+                generation = outcome.generation
+                for result in outcome.results { _ = try? logStore.save(result) }
+                message = outcome.failure == nil
                     ? "\(Self.actionTitle(action)) finished"
-                    : "\(Self.actionTitle(action)) failed with exit \(result.exitCode)"
-                if !result.succeeded {
-                    CrawlBarLog.actions.error(
-                        "\(action, privacy: .public) for \(appID.rawValue, privacy: .public) failed with exit \(result.exitCode)")
-                    actionError = Self.actionFailureStatus(result)
+                    : outcome.failure!.summary
+                actionError = outcome.failure
+            } catch CrawlActionCoordinatorError.busy {
+                await MainActor.run {
+                    self.runningActions[appID] = nil
+                    self.actionMessages[appID] = "An action is already running for this crawler"
                 }
+                return
             } catch {
                 CrawlBarLog.actions.error(
                     "\(action, privacy: .public) for \(appID.rawValue, privacy: .public) threw: \(error.localizedDescription, privacy: .public)")
@@ -101,12 +112,16 @@ extension CrawlBarSettingsModel {
                 configValues: registry.statusConfigValues(for: installation),
                 timeoutSeconds: 5)
             await MainActor.run {
+                self.runningActions[appID] = nil
+                if let generation, !CrawlActionCoordinator.shared.isCurrent(appID, generation: generation) {
+                    self.actionMessages[appID] = nil
+                    return
+                }
                 let status = actionError.map {
                     Self.actionFailureStatus($0, refreshedStatus: refreshedStatus, currentStatus: self.statuses[appID])
                 } ?? refreshedStatus
                 self.statuses[appID] = status
                 CrawlBarStateBroadcast.statusesDidChange([appID: status])
-                self.runningActions[appID] = nil
                 self.actionMessages[appID] = message
                 self.loadRecentResults()
             }

--- a/Sources/CrawlBar/Settings/SettingsModelStatusActions.swift
+++ b/Sources/CrawlBar/Settings/SettingsModelStatusActions.swift
@@ -73,6 +73,7 @@ extension CrawlBarSettingsModel {
         let registry = self.registry
         Task.detached {
             let actionConfigValues = registry.executionConfigValues(for: installation)
+            let nativePublicationGuard = registry.nativePublicationGuard(for: installation, configValues: actionConfigValues)
             let message: String
             var actionError: CrawlAppStatus?
             var generation: UInt64?
@@ -83,7 +84,9 @@ extension CrawlBarSettingsModel {
                     config: config,
                     configValues: actionConfigValues,
                     action: action,
-                    allowShare: { registry.matchesPersistedAppConfig(config, manifest: installation.manifest) },
+                    allowShare: {
+                        registry.matchesPersistedAppConfig(config, manifest: installation.manifest) && nativePublicationGuard()
+                    },
                     execute: { next in
                         try runner.run(
                             installation: installation, configValues: actionConfigValues,

--- a/Sources/CrawlBarCore/CommandRunner.swift
+++ b/Sources/CrawlBarCore/CommandRunner.swift
@@ -75,18 +75,7 @@ public struct CrawlCommandRunner: @unchecked Sendable {
             throw CrawlCommandRunnerError.executableNotFound(executableName)
         }
 
-        var commandEnvironment = self.environment
-        if let envName = installation.manifest.paths.configEnv,
-           let configPath = installation.configPathOverride?.nilIfBlank
-        {
-            commandEnvironment[envName] = PathExpander.expandHome(configPath)
-        }
-        for option in installation.manifest.configOptions {
-            guard let envName = option.envVar?.nilIfBlank,
-                  let value = configValues[option.id]?.nilIfBlank
-            else { continue }
-            commandEnvironment[envName] = value
-        }
+        let commandEnvironment = self.commandEnvironment(for: installation, configValues: configValues)
 
         if executionKind == .ssh {
             let remoteBinaryOverride = effectiveBinaryName == installation.manifest.binary.name
@@ -110,5 +99,31 @@ public struct CrawlCommandRunner: @unchecked Sendable {
             environment: commandEnvironment,
             maskedValues: maskedValues,
             timeoutSeconds: timeoutSeconds)
+    }
+
+    func commandEnvironment(for installation: CrawlAppInstallation, configValues: [String: String]) -> [String: String] {
+        var commandEnvironment = self.environment
+        if let envName = installation.manifest.paths.configEnv,
+           let configPath = installation.configPathOverride?.nilIfBlank
+        {
+            commandEnvironment[envName] = PathExpander.expandHome(configPath)
+        }
+        for option in installation.manifest.configOptions {
+            guard let envName = option.envVar?.nilIfBlank,
+                  let value = configValues[option.id]?.nilIfBlank
+            else { continue }
+            commandEnvironment[envName] = value
+        }
+        return commandEnvironment
+    }
+
+    func nativePublicationConfigPath(for installation: CrawlAppInstallation, configValues: [String: String]) -> String? {
+        let environment = self.commandEnvironment(for: installation, configValues: configValues)
+        if let key = installation.manifest.paths.configEnv, let path = environment[key] {
+            // Preserve the transported bytes, including a present empty selector.
+            return path
+        }
+        return (installation.configPathOverride?.nilIfBlank ?? installation.manifest.paths.defaultConfig?.nilIfBlank)
+            .map { PathExpander.expandHome($0) }
     }
 }

--- a/Sources/CrawlBarCore/Config/CrawlBarConfigStore.swift
+++ b/Sources/CrawlBarCore/Config/CrawlBarConfigStore.swift
@@ -19,9 +19,17 @@ public struct CrawlBarConfigStore: @unchecked Sendable {
     }
 
     public func load(includeSecrets: Bool = false) throws -> CrawlBarConfig? {
+        try self.load(includeSecrets: includeSecrets, useCache: true)
+    }
+
+    package func loadUncached() throws -> CrawlBarConfig? {
+        try self.load(includeSecrets: false, useCache: false)
+    }
+
+    private func load(includeSecrets: Bool, useCache: Bool) throws -> CrawlBarConfig? {
         guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return nil }
-        let modificationDate = self.modificationDate(for: self.fileURL)
-        if !includeSecrets,
+        let modificationDate = useCache ? self.modificationDate(for: self.fileURL) : nil
+        if useCache, !includeSecrets,
            let cached = self.cache.config(path: self.fileURL.path, modificationDate: modificationDate)
         {
             return cached
@@ -29,7 +37,7 @@ public struct CrawlBarConfigStore: @unchecked Sendable {
         let data = try Data(contentsOf: self.fileURL)
         do {
             let config = try CrawlCoding.makeJSONDecoder().decode(CrawlBarConfig.self, from: data).normalized()
-            if !includeSecrets {
+            if useCache, !includeSecrets {
                 self.cache.set(config, path: self.fileURL.path, modificationDate: modificationDate)
             }
             return includeSecrets ? self.configWithSecrets(config) : config

--- a/Sources/CrawlBarCore/CrawlActionCoordinator.swift
+++ b/Sources/CrawlBarCore/CrawlActionCoordinator.swift
@@ -1,0 +1,141 @@
+import CryptoKit
+import Foundation
+
+package enum CrawlActionCoordinatorError: LocalizedError {
+    case busy
+    case notDue
+
+    package var errorDescription: String? {
+        switch self {
+        case .busy: "An action is already running for this crawler"
+        case .notDue: "The scheduled action is not due"
+        }
+    }
+}
+
+package struct CrawlActionOutcome: Sendable {
+    package let results: [CrawlCommandResult]
+    package let failure: CrawlAppStatus?
+    package let generation: UInt64
+}
+
+// One in-process owner for menu/settings mutations. Archive writers still need
+// their own cross-process exclusion; independent status reads bypass this gate.
+package final class CrawlActionCoordinator: @unchecked Sendable {
+    package static let shared = CrawlActionCoordinator()
+
+    private struct PublishIdentity: Equatable {
+        let installation: CrawlAppInstallation
+        let refreshAction: String
+        let shareAction: String
+        let configDigest: Data
+    }
+
+    private let lock = NSLock()
+    private var running: Set<CrawlAppID> = []
+    private var attempts: [CrawlAppID: Date] = [:]
+    private var successes: [CrawlAppID: Date] = [:]
+    private var generations: [CrawlAppID: UInt64] = [:]
+    private var pendingPublish: [CrawlAppID: PublishIdentity] = [:]
+
+    package init() {}
+
+    package func isDue(_ appID: CrawlAppID, interval: TimeInterval, now: Date = Date()) -> Bool {
+        self.lock.withLock {
+            !self.running.contains(appID)
+                && now.timeIntervalSince(self.attempts[appID] ?? .distantPast) >= interval
+        }
+    }
+
+    package func isCurrent(_ appID: CrawlAppID, generation: UInt64) -> Bool {
+        self.lock.withLock { self.generations[appID] == generation }
+    }
+
+    package func lastSuccessfulSync(_ appID: CrawlAppID) -> Date? {
+        self.lock.withLock { self.successes[appID] }
+    }
+
+    package func run(
+        installation: CrawlAppInstallation,
+        config: CrawlBarAppConfig,
+        configValues: [String: String],
+        action: String,
+        now: Date = Date(),
+        scheduledInterval: TimeInterval? = nil,
+        allowShare: () -> Bool = { true },
+        execute: (String) throws -> CrawlCommandResult)
+        throws -> CrawlActionOutcome
+    {
+        let appID = installation.id
+        let refreshAction = config.preferredRefreshAction ?? "refresh"
+        let shareAction = config.preferredShareAction ?? "publish"
+        let refresh = action == refreshAction
+        let share = refresh && config.shareEnabled && config.shareAfterRefresh
+        let digest = Data(SHA256.hash(data: try JSONSerialization.data(withJSONObject: configValues, options: [.sortedKeys])))
+        let identity = PublishIdentity(
+            installation: installation, refreshAction: refreshAction,
+            shareAction: shareAction, configDigest: digest)
+        let (generation, resumePublish) = try self.lock.withLock {
+            guard !self.running.contains(appID) else { throw CrawlActionCoordinatorError.busy }
+            if let scheduledInterval, now.timeIntervalSince(self.attempts[appID] ?? .distantPast) < scheduledInterval {
+                throw CrawlActionCoordinatorError.notDue
+            }
+            self.running.insert(appID)
+            if refresh { self.attempts[appID] = now }
+            let generation = (self.generations[appID] ?? 0) &+ 1
+            self.generations[appID] = generation
+            let resume = scheduledInterval != nil && share && self.pendingPublish[appID] == identity
+            if self.pendingPublish[appID] != identity || !config.shareEnabled || !config.shareAfterRefresh
+                || (refresh && !resume) || (!refresh && action != shareAction)
+            {
+                self.pendingPublish[appID] = nil
+            }
+            return (generation, resume)
+        }
+        defer { self.lock.withLock { self.running.remove(appID) } }
+
+        var actions = resumePublish ? [shareAction] : [action]
+        if share && !resumePublish && shareAction != action { actions.append(shareAction) }
+        var results: [CrawlCommandResult] = []
+        for next in actions {
+            if Task.isCancelled {
+                return CrawlActionOutcome(
+                    results: results,
+                    failure: .commandFailure(appID: appID, action: next, message: "Action cancelled", fallback: "Action cancelled"),
+                    generation: generation)
+            }
+            if next == shareAction && share && !allowShare() {
+                self.lock.withLock { self.pendingPublish[appID] = nil }
+                break
+            }
+            do {
+                let result = try execute(next)
+                results.append(result)
+                guard result.succeeded else {
+                    return CrawlActionOutcome(
+                        results: results,
+                        failure: .commandFailure(
+                            appID: appID, action: next,
+                            message: result.stderr.nilIfBlank ?? result.stdout.nilIfBlank,
+                            fallback: "\(next) failed with exit \(result.exitCode)"),
+                        generation: generation)
+                }
+                self.lock.withLock {
+                    if next == refreshAction {
+                        self.successes[appID] = result.finishedAt
+                        self.pendingPublish[appID] = share ? identity : nil
+                    }
+                    if next == shareAction { self.pendingPublish[appID] = nil }
+                }
+            } catch {
+                return CrawlActionOutcome(
+                    results: results,
+                    failure: .commandFailure(
+                        appID: appID, action: next, message: error.localizedDescription,
+                        fallback: "\(next) failed"),
+                    generation: generation)
+            }
+        }
+        return CrawlActionOutcome(results: results, failure: nil, generation: generation)
+    }
+}

--- a/Sources/CrawlBarCore/CrawlCommandRunnerArguments.swift
+++ b/Sources/CrawlBarCore/CrawlCommandRunnerArguments.swift
@@ -155,20 +155,32 @@ extension CrawlCommandRunner {
         configValues: [String: String])
         throws -> String
     {
-        var value = argument
-        while let range = value.range(of: #"\{config:([A-Za-z0-9_.-]+)\}"#, options: .regularExpression) {
-            let token = String(value[range])
-            let optionID = String(token.dropFirst("{config:".count).dropLast())
-            guard let replacement = Self.configValue(
-                optionID,
-                installation: installation,
-                configValues: configValues)
-            else {
-                throw CrawlCommandRunnerError.missingRequiredConfig(appID: installation.id, optionID: optionID)
+        var steps = 0
+        let maximumBytes = 1_048_576
+        func expand(_ input: String, stack: Set<String>) throws -> String {
+            guard stack.count <= 64, input.utf8.count <= maximumBytes else {
+                throw CrawlCommandRunnerError.invalidConfigExpansion(appID: installation.id)
             }
-            value.replaceSubrange(range, with: replacement)
+            var value = input
+            while let range = value.range(of: #"\{config:([A-Za-z0-9_.-]+)\}"#, options: .regularExpression) {
+                steps += 1
+                let token = String(value[range])
+                let optionID = String(token.dropFirst("{config:".count).dropLast())
+                guard steps <= 4096, !stack.contains(optionID) else {
+                    throw CrawlCommandRunnerError.invalidConfigExpansion(appID: installation.id)
+                }
+                guard let raw = Self.configValue(optionID, installation: installation, configValues: configValues) else {
+                    throw CrawlCommandRunnerError.missingRequiredConfig(appID: installation.id, optionID: optionID)
+                }
+                let replacement = try expand(raw, stack: stack.union([optionID]))
+                guard value.utf8.count - token.utf8.count + replacement.utf8.count <= maximumBytes else {
+                    throw CrawlCommandRunnerError.invalidConfigExpansion(appID: installation.id)
+                }
+                value.replaceSubrange(range, with: replacement)
+            }
+            return value
         }
-        return value
+        return try expand(argument, stack: [])
     }
 
     private static func remoteShellCommand(commandParts: [String], envFile: String?) -> String {

--- a/Sources/CrawlBarCore/CrawlCommandRunnerError.swift
+++ b/Sources/CrawlBarCore/CrawlCommandRunnerError.swift
@@ -4,6 +4,7 @@ public enum CrawlCommandRunnerError: LocalizedError, Sendable {
     case executableNotFound(String)
     case commandUnavailable(appID: CrawlAppID, action: String)
     case missingRequiredConfig(appID: CrawlAppID, optionID: String)
+    case invalidConfigExpansion(appID: CrawlAppID)
     case invalidRemoteTarget(appID: CrawlAppID, target: String)
     case timedOut(appID: CrawlAppID, action: String, seconds: Int)
 
@@ -15,6 +16,8 @@ public enum CrawlCommandRunnerError: LocalizedError, Sendable {
             "\(appID.rawValue) does not expose a \(action) command"
         case let .missingRequiredConfig(appID, optionID):
             "\(appID.rawValue) is missing required config: \(optionID)"
+        case let .invalidConfigExpansion(appID):
+            "\(appID.rawValue) config interpolation contains a cycle or exceeds expansion limits"
         case let .invalidRemoteTarget(appID, target):
             "\(appID.rawValue) has an invalid SSH target: \(target)"
         case let .timedOut(appID, action, seconds):

--- a/Sources/CrawlBarCore/CrawlDatabaseInventory.swift
+++ b/Sources/CrawlBarCore/CrawlDatabaseInventory.swift
@@ -20,6 +20,9 @@ public enum CrawlDatabaseInventory {
             return Self.singleSQLiteResource(status: status, manifest: manifest, label: "Telegram archive", role: "Desktop archive")
         case BuiltInCrawlApps.notcrawlID:
             return Self.notcrawlResources(status: status, manifest: manifest)
+        case BuiltInCrawlApps.imsgcrawlID:
+            guard status.databasePath?.nilIfBlank != nil else { return [] }
+            return Self.singleSQLiteResource(status: status, manifest: manifest, label: "iMessage archive", role: nil)
         default:
             return Self.singleSQLiteResource(status: status, manifest: manifest, label: "Archive database", role: nil)
         }

--- a/Sources/CrawlBarCore/NativeConfig.swift
+++ b/Sources/CrawlBarCore/NativeConfig.swift
@@ -88,6 +88,13 @@ public struct CrawlNativeConfigStore: @unchecked Sendable {
         return values
     }
 
+    func publicationValues(path: String, manifest: CrawlAppManifest, optionIDs: Set<String>) throws -> [String: String] {
+        guard self.fileManager.fileExists(atPath: path) else {
+            throw CocoaError(.fileReadNoSuchFile)
+        }
+        return try self.read(path: path, manifest: manifest).filter { optionIDs.contains($0.key) }
+    }
+
     private func cachedRead(path: String, manifest: CrawlAppManifest) -> [String: String] {
         let expandedPath = PathExpander.expandHome(path)
         guard self.fileManager.fileExists(atPath: expandedPath) else { return [:] }

--- a/Sources/CrawlBarCore/Registry.swift
+++ b/Sources/CrawlBarCore/Registry.swift
@@ -126,6 +126,17 @@ public struct CrawlAppRegistry: @unchecked Sendable {
         return copy
     }
 
+    package func matchesPersistedAppConfig(_ captured: CrawlBarAppConfig, manifest: CrawlAppManifest) -> Bool {
+        guard let config = try? self.configStore.load(includeSecrets: false),
+              let current = config.apps.first(where: { $0.id == captured.id })
+        else { return false }
+        // Keep the pre-action values frozen; only enrich the current config.
+        let secretIDs = Set(manifest.configOptions.filter { $0.kind == .secret }.map(\.id))
+        var baseline = captured
+        baseline.configValues = baseline.configValues.filter { !secretIDs.contains($0.key) }
+        return self.appConfigWithNativeValues(current, manifest: manifest, includeSecrets: false) == baseline
+    }
+
     private func installationWithSecrets(_ installation: CrawlAppInstallation) -> CrawlAppInstallation {
         return CrawlAppInstallation(
             manifest: installation.manifest,

--- a/Sources/CrawlBarCore/Registry.swift
+++ b/Sources/CrawlBarCore/Registry.swift
@@ -137,6 +137,30 @@ public struct CrawlAppRegistry: @unchecked Sendable {
         return self.appConfigWithNativeValues(current, manifest: manifest, includeSecrets: false) == baseline
     }
 
+    package func nativePublicationGuard(
+        for installation: CrawlAppInstallation,
+        configValues: [String: String])
+        -> @Sendable () -> Bool
+    {
+        let manifest = installation.manifest
+        guard manifest.executionKind(configValues: configValues) == .local else { return { true } }
+        let optionIDs = Set(manifest.configOptions.filter {
+            $0.kind != .secret && $0.configKey?.nilIfBlank != nil && $0.envVar?.nilIfBlank == nil
+        }.map(\.id))
+        guard !optionIDs.isEmpty else { return { true } }
+        // Freeze only the declared nonsecret values supplied to this execution, including retries.
+        let expected = configValues.filter { optionIDs.contains($0.key) }
+        let path = (installation.configPathOverride?.nilIfBlank ?? manifest.paths.defaultConfig?.nilIfBlank)
+            .map { PathExpander.expandHome($0) }
+        let nativeStore = self.nativeConfigStore
+        return {
+            guard let path,
+                  let current = try? nativeStore.publicationValues(path: path, manifest: manifest, optionIDs: optionIDs)
+            else { return false }
+            return current == expected
+        }
+    }
+
     private func installationWithSecrets(_ installation: CrawlAppInstallation) -> CrawlAppInstallation {
         return CrawlAppInstallation(
             manifest: installation.manifest,

--- a/Sources/CrawlBarCore/Registry.swift
+++ b/Sources/CrawlBarCore/Registry.swift
@@ -139,7 +139,8 @@ public struct CrawlAppRegistry: @unchecked Sendable {
 
     package func nativePublicationGuard(
         for installation: CrawlAppInstallation,
-        configValues: [String: String])
+        configValues: [String: String],
+        runner: CrawlCommandRunner)
         -> @Sendable () -> Bool
     {
         let manifest = installation.manifest
@@ -150,8 +151,7 @@ public struct CrawlAppRegistry: @unchecked Sendable {
         guard !optionIDs.isEmpty else { return { true } }
         // Freeze only the declared nonsecret values supplied to this execution, including retries.
         let expected = configValues.filter { optionIDs.contains($0.key) }
-        let path = (installation.configPathOverride?.nilIfBlank ?? manifest.paths.defaultConfig?.nilIfBlank)
-            .map { PathExpander.expandHome($0) }
+        let path = runner.nativePublicationConfigPath(for: installation, configValues: configValues)
         let nativeStore = self.nativeConfigStore
         return {
             guard let path,

--- a/Sources/CrawlBarCore/Registry.swift
+++ b/Sources/CrawlBarCore/Registry.swift
@@ -127,7 +127,7 @@ public struct CrawlAppRegistry: @unchecked Sendable {
     }
 
     package func matchesPersistedAppConfig(_ captured: CrawlBarAppConfig, manifest: CrawlAppManifest) -> Bool {
-        guard let config = try? self.configStore.load(includeSecrets: false),
+        guard let config = try? self.configStore.loadUncached(),
               let current = config.apps.first(where: { $0.id == captured.id })
         else { return false }
         // Keep the pre-action values frozen; only enrich the current config.

--- a/Sources/CrawlBarCore/StatusMapperCrawlKit.swift
+++ b/Sources/CrawlBarCore/StatusMapperCrawlKit.swift
@@ -21,6 +21,7 @@ extension CrawlStatusMapper {
         let observedDataAt = lastSyncAt ?? lastImportAt
             ?? remote?.lastSyncAt
             ?? remote?.lastIngestAt
+            ?? object["updated_at"].flatMap { self.date($0) }
         let freshness = self.freshness(in: object, lastSyncAt: observedDataAt, staleAfterSeconds: staleAfterSeconds)
         return CrawlAppStatus(
             appID: result.appID,

--- a/Sources/CrawlBarCore/StatusMapperCrawlKit.swift
+++ b/Sources/CrawlBarCore/StatusMapperCrawlKit.swift
@@ -3,23 +3,37 @@ import Foundation
 extension CrawlStatusMapper {
     func genericStatus(_ object: [String: Any], result: CrawlCommandResult, staleAfterSeconds: Int?) -> CrawlAppStatus {
         let counts = self.statusCounts(in: object, fallback: self.counts(in: object))
-        let databases = self.databaseResources(in: object)
+        let imsgArchive = (object["archive"] as? [String: Any]) ?? object
+        let isImsg = result.appID == BuiltInCrawlApps.imsgcrawlID
+        // The iMessage envelope also contains a source database_path. Never
+        // expose that source as an archive resource: backup selects all SQLite rows.
+        let databasePath = isImsg
+            ? (imsgArchive["archive_path"] as? String)?.nilIfBlank
+            : self.stringValue(["db_path", "database_path"], in: object)
+        let databases = self.databaseResources(in: object).filter {
+            !isImsg || ($0.path != nil && $0.path == databasePath)
+        }
         let remote = self.remoteStatus(in: object)
-        let lastSyncAt = self.dateValue(["last_sync_at", "updated_at", "generated_at"], in: object)
+        let lastImportAt = self.dateValue(["last_import_at"], in: object)
+        let lastSyncAt = self.dateValue(["last_sync_at"], in: object)
             ?? remote?.lastSyncAt
             ?? remote?.lastIngestAt
-            ?? self.databaseModifiedAt(databases)
-        let freshness = self.freshness(in: object, lastSyncAt: lastSyncAt, staleAfterSeconds: staleAfterSeconds)
+        let observedDataAt = lastSyncAt ?? lastImportAt
+            ?? remote?.lastSyncAt
+            ?? remote?.lastIngestAt
+        let freshness = self.freshness(in: object, lastSyncAt: observedDataAt, staleAfterSeconds: staleAfterSeconds)
         return CrawlAppStatus(
             appID: result.appID,
-            state: self.statusState(in: object, lastSyncAt: lastSyncAt, freshness: freshness, fallback: .current, staleAfterSeconds: staleAfterSeconds),
-            summary: self.stringValue(["summary", "message"], in: object) ?? self.summary(from: counts, fallback: "Status is current"),
+            state: self.statusState(in: object, lastSyncAt: observedDataAt, freshness: freshness, fallback: .current, staleAfterSeconds: staleAfterSeconds),
+            summary: self.stringValue(["summary", "message"], in: object) ?? self.summary(from: counts, fallback: "Status received"),
             configPath: self.stringValue(["config_path", "config"], in: object),
-            databasePath: self.stringValue(["db_path", "database_path"], in: object),
-            databaseBytes: self.intValue(["db_bytes", "database_bytes"], in: object),
+            databasePath: databasePath,
+            databaseBytes: isImsg
+                ? self.intValue(["archive_bytes"], in: imsgArchive)
+                : self.intValue(["db_bytes", "database_bytes"], in: object),
             walBytes: self.intValue(["wal_bytes"], in: object),
             lastSyncAt: lastSyncAt,
-            lastImportAt: self.dateValue(["last_import_at"], in: object),
+            lastImportAt: lastImportAt,
             lastExportAt: self.dateValue(["last_export_at"], in: object),
             counts: counts,
             databases: databases,

--- a/Sources/CrawlBarCore/StatusMapperJSON.swift
+++ b/Sources/CrawlBarCore/StatusMapperJSON.swift
@@ -55,8 +55,10 @@ extension CrawlStatusMapper {
             return .stale
         case "failed", "failure", "source_error", "archive_error":
             return .error
+        case "missing":
+            return .needsConfig
         default:
-            return nil
+            return .unknown
         }
     }
 

--- a/Sources/CrawlBarSelfTest/SelfTest.swift
+++ b/Sources/CrawlBarSelfTest/SelfTest.swift
@@ -4,6 +4,17 @@ import Foundation
 @main
 enum CrawlBarSelfTest {
     static func main() throws {
+        try Self.testNativeArchiveMappingAndBackupSelection()
+        try Self.testNativeStatusFreshnessAndMissingState()
+        try Self.testNativeRecursiveConfigExpansion()
+        try Self.testActionAttemptCadenceAndShareRetry()
+        try Self.testActionExclusionAndConsent()
+        try Self.testActionSelectedArgumentsAndChangedConfig()
+        try Self.testExistingCredentialFixOnFailureLogs()
+        if CommandLine.arguments.contains("--native-safety") {
+            print("crawlbar synthetic native safety selftest ok")
+            return
+        }
         try Self.testAppIDSortsByRawValue()
         try Self.testDefaultConfigNormalizesBuiltInApps()
         try Self.testConfigStoreRoundTrips()

--- a/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
@@ -176,7 +176,8 @@ extension CrawlBarSelfTest {
             let actionConfigValues = ["destination": "original"]
             let installation = CrawlAppInstallation(
                 manifest: manifest, configPathOverride: nativeURL.path, configValues: actionConfigValues)
-            let nativePublicationGuard = registry.nativePublicationGuard(for: installation, configValues: actionConfigValues)
+            let runner = CrawlCommandRunner(environment: ["HOME": directory.path, "TMPDIR": directory.path, "PATH": "/usr/bin:/bin"])
+            let nativePublicationGuard = registry.nativePublicationGuard(for: installation, configValues: actionConfigValues, runner: runner)
             let coordinator = CrawlActionCoordinator()
             var calls: [String] = []
             var overwrittenMainData: Data?

--- a/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
@@ -118,6 +118,102 @@ extension CrawlBarSelfTest {
             return Self.actionFixtureResult(installation.id, action: action, exitCode: 0)
         }
         try Self.expect(calls == ["pull", "share"], "explicit manual sync never turns into a publish-only retry")
+        try Self.testSettingsShareConfigSnapshot()
+    }
+
+    static func testSettingsShareConfigSnapshot() throws {
+        for change in [
+            "unchanged", "secret-only", "share-disabled", "after-refresh-disabled",
+            "missing-app", "missing-main", "corrupt-main", "persisted-destination",
+            "native-destination", "config-path", "share-action", "refresh-action", "other-setting",
+        ] {
+            let directory = FileManager.default.temporaryDirectory.appendingPathComponent("crawlbar-share-config-\(UUID())")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: directory) }
+            let mainURL = directory.appendingPathComponent("config.json")
+            let nativeURL = directory.appendingPathComponent("native.toml")
+            var manifest = Self.nativeFixtureManifest(commands: ["pull": [], "share": []])
+            manifest.configOptions = [
+                .init(id: "destination", label: "Destination", configKey: "share.destination"),
+                .init(id: "fixture_secret", label: "Fixture secret", kind: .secret, configKey: "auth.fixture"),
+            ]
+            let app = CrawlBarAppConfig(
+                id: manifest.id, configPath: nativeURL.path, preferredRefreshAction: "pull",
+                shareEnabled: true, shareAfterRefresh: true, preferredShareAction: "share")
+            let store = CrawlBarConfigStore(fileURL: mainURL, cache: CrawlBarConfigCache())
+            let nativeStore = CrawlNativeConfigStore(cache: CrawlNativeConfigCache())
+            let registry = CrawlAppRegistry(configStore: store, nativeConfigStore: nativeStore)
+            // No external manifests or secret-store calls are needed for this fixture.
+            var persisted = CrawlBarConfig(manifestDirectories: [directory.appendingPathComponent("apps").path], apps: [app])
+            try store.save(persisted)
+            var native = app
+            native.configValues = ["destination": "original", "fixture_secret": UUID().uuidString]
+            try nativeStore.write(appConfig: native, manifest: manifest)
+            var baseline = registry.appConfigWithNativeValues(app, manifest: manifest, includeSecrets: false)
+            try Self.expect(baseline.configValues == ["destination": "original"], "Settings baseline contains native nonsecret values")
+            baseline.configValues["fixture_secret"] = UUID().uuidString
+            let installation = CrawlAppInstallation(manifest: manifest)
+            let coordinator = CrawlActionCoordinator()
+            var calls: [String] = []
+            let outcome = try coordinator.run(
+                installation: installation, config: baseline, configValues: [:], action: "pull",
+                allowShare: { registry.matchesPersistedAppConfig(baseline, manifest: manifest) })
+            { action in
+                calls.append(action)
+                if action == "pull" {
+                    switch change {
+                    case "share-disabled": persisted.apps[0].shareEnabled = false
+                    case "after-refresh-disabled": persisted.apps[0].shareAfterRefresh = false
+                    case "missing-app": persisted.apps.removeAll()
+                    case "persisted-destination": persisted.apps[0].configValues["destination"] = "changed"
+                    case "config-path": persisted.apps[0].configPath = directory.appendingPathComponent("other.toml").path
+                    case "share-action": persisted.apps[0].preferredShareAction = "other-share"
+                    case "refresh-action": persisted.apps[0].preferredRefreshAction = "other-refresh"
+                    case "other-setting": persisted.apps[0].showInMenuBar = false
+                    case "native-destination", "secret-only":
+                        if change == "secret-only" {
+                            native.configValues["fixture_secret"] = UUID().uuidString
+                        } else {
+                            native.configValues["destination"] = "changed"
+                        }
+                        try nativeStore.write(appConfig: native, manifest: manifest)
+                    default: break
+                    }
+                    switch change {
+                    case "missing-main":
+                        try FileManager.default.removeItem(at: mainURL)
+                    case "corrupt-main":
+                        try Data("not-json".utf8).write(to: mainURL)
+                        // Deterministically invalidate the existing mtime-based cache.
+                        try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSince1970: 0)], ofItemAtPath: mainURL.path)
+                    default:
+                        try store.save(persisted)
+                    }
+                }
+                return Self.actionFixtureResult(manifest.id, action: action, exitCode: 0)
+            }
+            let shouldPublish = change == "unchanged" || change == "secret-only"
+            try Self.expect(outcome.failure == nil && calls == (shouldPublish ? ["pull", "share"] : ["pull"]), "Settings share gate: \(change)")
+            var shareGateCalls = 0
+            calls = []
+            _ = try coordinator.run(
+                installation: installation, config: baseline, configValues: [:], action: "share",
+                allowShare: {
+                    shareGateCalls += 1
+                    return registry.matchesPersistedAppConfig(baseline, manifest: manifest)
+                })
+            { action in
+                calls.append(action)
+                return Self.actionFixtureResult(manifest.id, action: action, exitCode: 0)
+            }
+            try Self.expect(calls == ["share"] && shareGateCalls == 0, "standalone publication bypasses only the between-phase gate")
+            if change == "missing-main" {
+                try Self.expect(!FileManager.default.fileExists(atPath: mainURL.path), "share gate never recreates a missing main config")
+            } else if change == "corrupt-main" {
+                let data = try Data(contentsOf: mainURL)
+                try Self.expect(data == Data("not-json".utf8), "share gate never repairs a corrupt main config")
+            }
+        }
     }
 
     static func actionFixtureResult(_ appID: CrawlAppID, action: String, exitCode: Int32, date: Date = Date()) -> CrawlCommandResult {

--- a/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
@@ -119,6 +119,7 @@ extension CrawlBarSelfTest {
         }
         try Self.expect(calls == ["pull", "share"], "explicit manual sync never turns into a publish-only retry")
         try Self.testSettingsShareConfigSnapshot()
+        try Self.testNativePublicationGuard()
     }
 
     static func testSettingsShareConfigSnapshot() throws {
@@ -172,13 +173,18 @@ extension CrawlBarSelfTest {
             var baseline = registry.appConfigWithNativeValues(app, manifest: manifest, includeSecrets: false)
             try Self.expect(baseline.configValues == ["destination": "original"], "Settings baseline contains native nonsecret values")
             baseline.configValues["fixture_secret"] = UUID().uuidString
-            let installation = CrawlAppInstallation(manifest: manifest)
+            let actionConfigValues = ["destination": "original"]
+            let installation = CrawlAppInstallation(
+                manifest: manifest, configPathOverride: nativeURL.path, configValues: actionConfigValues)
+            let nativePublicationGuard = registry.nativePublicationGuard(for: installation, configValues: actionConfigValues)
             let coordinator = CrawlActionCoordinator()
             var calls: [String] = []
             var overwrittenMainData: Data?
             let outcome = try coordinator.run(
-                installation: installation, config: baseline, configValues: [:], action: "pull",
-                allowShare: { registry.matchesPersistedAppConfig(baseline, manifest: manifest) })
+                installation: installation, config: baseline, configValues: actionConfigValues, action: "pull",
+                allowShare: {
+                    registry.matchesPersistedAppConfig(baseline, manifest: manifest) && nativePublicationGuard()
+                })
             { action in
                 calls.append(action)
                 if action == "pull" {
@@ -235,10 +241,10 @@ extension CrawlBarSelfTest {
             var shareGateCalls = 0
             calls = []
             _ = try coordinator.run(
-                installation: installation, config: baseline, configValues: [:], action: "share",
+                installation: installation, config: baseline, configValues: actionConfigValues, action: "share",
                 allowShare: {
                     shareGateCalls += 1
-                    return registry.matchesPersistedAppConfig(baseline, manifest: manifest)
+                    return registry.matchesPersistedAppConfig(baseline, manifest: manifest) && nativePublicationGuard()
                 })
             { action in
                 calls.append(action)

--- a/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
@@ -1,0 +1,129 @@
+import CrawlBarCore
+import Foundation
+
+extension CrawlBarSelfTest {
+    static func testActionAttemptCadenceAndShareRetry() throws {
+        let coordinator = CrawlActionCoordinator()
+        let installation = CrawlAppInstallation(manifest: Self.nativeFixtureManifest(commands: ["pull": ["sync", "--selected"], "share": ["publish", "--selected"]]))
+        let config = CrawlBarAppConfig(id: installation.id, preferredRefreshAction: "pull", shareEnabled: true, shareAfterRefresh: true, preferredShareAction: "share")
+        let now = Date(timeIntervalSince1970: 1000)
+        var called: [String] = []
+        let first = try coordinator.run(installation: installation, config: config, configValues: [:], action: "pull", now: now) { action in
+            called.append(action)
+            return Self.actionFixtureResult(installation.id, action: action, exitCode: action == "share" ? 1 : 0, date: now)
+        }
+        try Self.expect(called == ["pull", "share"] && first.failure != nil, "successful sync and failed share remain separate phases")
+        try Self.expect(coordinator.lastSuccessfulSync(installation.id) == now, "successful sync survives a failed publication")
+        try Self.expect(!coordinator.isDue(installation.id, interval: 900, now: now.addingTimeInterval(60)), "failed share cannot retry on every one-minute tick")
+        called = []
+        _ = try coordinator.run(installation: installation, config: config, configValues: [:], action: "pull", now: now.addingTimeInterval(900), scheduledInterval: 900) { action in
+            called.append(action)
+            return Self.actionFixtureResult(installation.id, action: action, exitCode: 0, date: now)
+        }
+        try Self.expect(called == ["share"], "retry publication without recrawling")
+        do {
+            _ = try coordinator.run(installation: installation, config: config, configValues: [:], action: "pull", now: now.addingTimeInterval(901), scheduledInterval: 900) { _ in
+                throw SelfTestError.failed("not-due scheduled action executed")
+            }
+            throw SelfTestError.failed("stale due-list entry was accepted")
+        } catch CrawlActionCoordinatorError.notDue {
+        }
+    }
+
+    static func testActionExclusionAndConsent() throws {
+        let coordinator = CrawlActionCoordinator()
+        let installation = CrawlAppInstallation(manifest: Self.nativeFixtureManifest(commands: ["refresh": [], "publish": []]))
+        let config = CrawlBarAppConfig(id: installation.id, shareEnabled: true, shareAfterRefresh: true)
+        let other = CrawlAppInstallation(manifest: BuiltInCrawlApps.imsgcrawl)
+        _ = try coordinator.run(installation: installation, config: config, configValues: [:], action: "refresh", allowShare: { false }) { action in
+            try Self.expect(action == "refresh", "revoked consent prevents publication")
+            do {
+                _ = try coordinator.run(installation: installation, config: config, configValues: [:], action: "refresh") { _ in
+                    throw SelfTestError.failed("overlapping same-crawler action executed")
+                }
+                throw SelfTestError.failed("same-crawler mutation was not excluded")
+            } catch CrawlActionCoordinatorError.busy {
+            }
+            _ = try coordinator.run(installation: other, config: .init(id: other.id), configValues: [:], action: "refresh") { next in
+                Self.actionFixtureResult(other.id, action: next, exitCode: 0)
+            }
+            return Self.actionFixtureResult(installation.id, action: action, exitCode: 0)
+        }
+        for enabled in [false, true] {
+            for afterRefresh in [false, true] {
+                var calls: [String] = []
+                let selected = CrawlBarAppConfig(id: installation.id, shareEnabled: enabled, shareAfterRefresh: afterRefresh)
+                _ = try coordinator.run(installation: installation, config: selected, configValues: [:], action: "refresh") { action in
+                    calls.append(action)
+                    return Self.actionFixtureResult(installation.id, action: action, exitCode: 0)
+                }
+                try Self.expect(calls == (enabled && afterRefresh ? ["refresh", "publish"] : ["refresh"]), "manual sync respects both share consent settings")
+            }
+        }
+        var calls: [String] = []
+        let failed = try coordinator.run(installation: installation, config: config, configValues: [:], action: "refresh") { action in
+            calls.append(action)
+            return Self.actionFixtureResult(installation.id, action: action, exitCode: 1)
+        }
+        try Self.expect(calls == ["refresh"] && failed.failure != nil, "failed sync cannot publish")
+        let next = try coordinator.run(installation: installation, config: config, configValues: [:], action: "refresh") { action in
+            Self.actionFixtureResult(installation.id, action: action, exitCode: 0)
+        }
+        try Self.expect(!coordinator.isCurrent(installation.id, generation: failed.generation) && coordinator.isCurrent(installation.id, generation: next.generation), "later actions invalidate stale completion updates")
+    }
+
+    static func testActionSelectedArgumentsAndChangedConfig() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("crawlbar-actions-\(UUID())")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let coordinator = CrawlActionCoordinator()
+        let manifest = Self.nativeFixtureManifest(commands: [
+            "pull": ["%s", "sync:{config:selection}"],
+            "share": ["%s", "publish:{config:selection}"],
+        ])
+        let installation = CrawlAppInstallation(manifest: manifest, binaryPath: "/usr/bin/printf")
+        let config = CrawlBarAppConfig(
+            id: installation.id, preferredRefreshAction: "pull",
+            shareEnabled: true, shareAfterRefresh: true, preferredShareAction: "share")
+        let runner = CrawlCommandRunner(environment: ["HOME": directory.path, "PATH": "/usr/bin:/bin"])
+        let outcome = try coordinator.run(
+            installation: installation, config: config, configValues: ["selection": "chosen"], action: "pull")
+        { action in
+            try runner.run(
+                installation: installation, configValues: ["selection": "chosen"],
+                action: action, timeoutSeconds: 5)
+        }
+        try Self.expect(outcome.results.map(\.stdout) == ["sync:chosen", "publish:chosen"], "selected action argv reaches the actual runner for both phases")
+        _ = try coordinator.run(
+            installation: installation, config: config, configValues: ["selection": "old"], action: "pull")
+        { action in
+            Self.actionFixtureResult(installation.id, action: action, exitCode: action == "share" ? 1 : 0)
+        }
+        var calls: [String] = []
+        _ = try coordinator.run(
+            installation: installation, config: config, configValues: ["selection": "new"], action: "pull")
+        { action in
+            calls.append(action)
+            return Self.actionFixtureResult(installation.id, action: action, exitCode: 0)
+        }
+        try Self.expect(calls == ["pull", "share"], "changed configuration invalidates a share-only retry")
+        _ = try coordinator.run(
+            installation: installation, config: config, configValues: [:], action: "pull")
+        { action in
+            Self.actionFixtureResult(installation.id, action: action, exitCode: action == "share" ? 1 : 0)
+        }
+        calls = []
+        _ = try coordinator.run(installation: installation, config: config, configValues: [:], action: "pull") { action in
+            calls.append(action)
+            return Self.actionFixtureResult(installation.id, action: action, exitCode: 0)
+        }
+        try Self.expect(calls == ["pull", "share"], "explicit manual sync never turns into a publish-only retry")
+    }
+
+    static func actionFixtureResult(_ appID: CrawlAppID, action: String, exitCode: Int32, date: Date = Date()) -> CrawlCommandResult {
+        CrawlCommandResult(
+            appID: appID, action: action, exitCode: exitCode,
+            stdout: "", stderr: exitCode == 0 ? "" : "synthetic failure",
+            startedAt: date, finishedAt: date)
+    }
+}

--- a/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
@@ -126,6 +126,7 @@ extension CrawlBarSelfTest {
             "unchanged", "secret-only", "share-disabled", "after-refresh-disabled",
             "missing-app", "missing-main", "corrupt-main", "persisted-destination",
             "native-destination", "config-path", "share-action", "refresh-action", "other-setting",
+            "same-mtime-consent", "same-mtime-destination", "same-mtime-corrupt",
         ] {
             let directory = FileManager.default.temporaryDirectory.appendingPathComponent("crawlbar-share-config-\(UUID())")
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -146,6 +147,12 @@ extension CrawlBarSelfTest {
             // No external manifests or secret-store calls are needed for this fixture.
             var persisted = CrawlBarConfig(manifestDirectories: [directory.appendingPathComponent("apps").path], apps: [app])
             try store.save(persisted)
+            let primed = try store.load(includeSecrets: false)
+            try Self.expect(primed?.apps.contains(where: { $0.id == app.id && $0.shareEnabled }) == true, "main config cache is primed with consent")
+            let attributes = try FileManager.default.attributesOfItem(atPath: mainURL.path)
+            guard let originalModificationDate = attributes[.modificationDate] as? Date else {
+                throw SelfTestError.failed("main config fixture has no modification date")
+            }
             var native = app
             native.configValues = ["destination": "original", "fixture_secret": UUID().uuidString]
             try nativeStore.write(appConfig: native, manifest: manifest)
@@ -155,6 +162,7 @@ extension CrawlBarSelfTest {
             let installation = CrawlAppInstallation(manifest: manifest)
             let coordinator = CrawlActionCoordinator()
             var calls: [String] = []
+            var overwrittenMainData: Data?
             let outcome = try coordinator.run(
                 installation: installation, config: baseline, configValues: [:], action: "pull",
                 allowShare: { registry.matchesPersistedAppConfig(baseline, manifest: manifest) })
@@ -162,10 +170,10 @@ extension CrawlBarSelfTest {
                 calls.append(action)
                 if action == "pull" {
                     switch change {
-                    case "share-disabled": persisted.apps[0].shareEnabled = false
+                    case "share-disabled", "same-mtime-consent": persisted.apps[0].shareEnabled = false
                     case "after-refresh-disabled": persisted.apps[0].shareAfterRefresh = false
                     case "missing-app": persisted.apps.removeAll()
-                    case "persisted-destination": persisted.apps[0].configValues["destination"] = "changed"
+                    case "persisted-destination", "same-mtime-destination": persisted.apps[0].configValues["destination"] = "changed"
                     case "config-path": persisted.apps[0].configPath = directory.appendingPathComponent("other.toml").path
                     case "share-action": persisted.apps[0].preferredShareAction = "other-share"
                     case "refresh-action": persisted.apps[0].preferredRefreshAction = "other-refresh"
@@ -184,8 +192,21 @@ extension CrawlBarSelfTest {
                         try FileManager.default.removeItem(at: mainURL)
                     case "corrupt-main":
                         try Data("not-json".utf8).write(to: mainURL)
-                        // Deterministically invalidate the existing mtime-based cache.
+                        // Retain the original changed-mtime corrupt-file regression.
                         try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSince1970: 0)], ofItemAtPath: mainURL.path)
+                    case "same-mtime-consent", "same-mtime-destination", "same-mtime-corrupt":
+                        let data: Data
+                        if change == "same-mtime-corrupt" {
+                            data = Data("not-json".utf8)
+                        } else {
+                            data = try CrawlCoding.makeJSONEncoder().encode(persisted)
+                        }
+                        // External edits must not refresh the in-memory config cache.
+                        try data.write(to: mainURL)
+                        overwrittenMainData = data
+                        try FileManager.default.setAttributes([.modificationDate: originalModificationDate], ofItemAtPath: mainURL.path)
+                        let current = try FileManager.default.attributesOfItem(atPath: mainURL.path)
+                        try Self.expect(current[.modificationDate] as? Date == originalModificationDate, "external config overwrite preserves actual mtime")
                     default:
                         try store.save(persisted)
                     }
@@ -210,9 +231,15 @@ extension CrawlBarSelfTest {
             try Self.expect(calls == ["share"] && shareGateCalls == 0, "standalone publication bypasses only the between-phase gate")
             if change == "missing-main" {
                 try Self.expect(!FileManager.default.fileExists(atPath: mainURL.path), "share gate never recreates a missing main config")
-            } else if change == "corrupt-main" {
+            } else if change == "corrupt-main" || change == "same-mtime-corrupt" {
                 let data = try Data(contentsOf: mainURL)
                 try Self.expect(data == Data("not-json".utf8), "share gate never repairs a corrupt main config")
+            }
+            if let overwrittenMainData {
+                let data = try Data(contentsOf: mainURL)
+                let current = try FileManager.default.attributesOfItem(atPath: mainURL.path)
+                try Self.expect(data == overwrittenMainData, "share gate leaves externally overwritten config bytes intact")
+                try Self.expect(current[.modificationDate] as? Date == originalModificationDate, "share gate leaves external config mtime intact")
             }
         }
     }

--- a/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
@@ -146,13 +146,26 @@ extension CrawlBarSelfTest {
             let registry = CrawlAppRegistry(configStore: store, nativeConfigStore: nativeStore)
             // No external manifests or secret-store calls are needed for this fixture.
             var persisted = CrawlBarConfig(manifestDirectories: [directory.appendingPathComponent("apps").path], apps: [app])
-            try store.save(persisted)
-            let primed = try store.load(includeSecrets: false)
-            try Self.expect(primed?.apps.contains(where: { $0.id == app.id && $0.shareEnabled }) == true, "main config cache is primed with consent")
+            let sameMtime = change.hasPrefix("same-mtime-")
+            let fixedModificationDate = Date(timeIntervalSince1970: 1_700_000_000)
+            if sameMtime {
+                // save also primes the cache; establish the fixture first.
+                try CrawlCoding.makeJSONEncoder().encode(persisted.normalized()).write(to: mainURL)
+                try FileManager.default.setAttributes([.modificationDate: fixedModificationDate], ofItemAtPath: mainURL.path)
+            } else {
+                try store.save(persisted)
+            }
             let attributes = try FileManager.default.attributesOfItem(atPath: mainURL.path)
             guard let originalModificationDate = attributes[.modificationDate] as? Date else {
                 throw SelfTestError.failed("main config fixture has no modification date")
             }
+            if sameMtime {
+                try Self.expect(
+                    originalModificationDate == fixedModificationDate,
+                    "initial config mtime: expected \(fixedModificationDate.timeIntervalSince1970), observed \(originalModificationDate.timeIntervalSince1970)")
+            }
+            let primed = try store.load(includeSecrets: false)
+            try Self.expect(primed?.apps.contains(where: { $0.id == app.id && $0.shareEnabled }) == true, "main config cache is primed with consent")
             var native = app
             native.configValues = ["destination": "original", "fixture_secret": UUID().uuidString]
             try nativeStore.write(appConfig: native, manifest: manifest)
@@ -206,7 +219,10 @@ extension CrawlBarSelfTest {
                         overwrittenMainData = data
                         try FileManager.default.setAttributes([.modificationDate: originalModificationDate], ofItemAtPath: mainURL.path)
                         let current = try FileManager.default.attributesOfItem(atPath: mainURL.path)
-                        try Self.expect(current[.modificationDate] as? Date == originalModificationDate, "external config overwrite preserves actual mtime")
+                        let observedDate = current[.modificationDate] as? Date
+                        try Self.expect(
+                            observedDate == originalModificationDate,
+                            "external config overwrite mtime: expected \(originalModificationDate.timeIntervalSince1970), observed \(observedDate.map { String($0.timeIntervalSince1970) } ?? "missing")")
                     default:
                         try store.save(persisted)
                     }
@@ -239,7 +255,10 @@ extension CrawlBarSelfTest {
                 let data = try Data(contentsOf: mainURL)
                 let current = try FileManager.default.attributesOfItem(atPath: mainURL.path)
                 try Self.expect(data == overwrittenMainData, "share gate leaves externally overwritten config bytes intact")
-                try Self.expect(current[.modificationDate] as? Date == originalModificationDate, "share gate leaves external config mtime intact")
+                let observedDate = current[.modificationDate] as? Date
+                try Self.expect(
+                    observedDate == originalModificationDate,
+                    "post-gate config mtime: expected \(originalModificationDate.timeIntervalSince1970), observed \(observedDate.map { String($0.timeIntervalSince1970) } ?? "missing")")
             }
         }
     }

--- a/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestActionCoordinator.swift
@@ -193,7 +193,8 @@ extension CrawlBarSelfTest {
                 return Self.actionFixtureResult(manifest.id, action: action, exitCode: 0)
             }
             let shouldPublish = change == "unchanged" || change == "secret-only"
-            try Self.expect(outcome.failure == nil && calls == (shouldPublish ? ["pull", "share"] : ["pull"]), "Settings share gate: \(change)")
+            try Self.expect(outcome.failure == nil, "Settings share fixture \(change): \(outcome.failure?.summary ?? "no action error")")
+            try Self.expect(calls == (shouldPublish ? ["pull", "share"] : ["pull"]), "Settings share gate \(change): actions \(calls)")
             var shareGateCalls = 0
             calls = []
             _ = try coordinator.run(

--- a/Sources/CrawlBarSelfTest/SelfTestNativeConfigEnvironment.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestNativeConfigEnvironment.swift
@@ -1,0 +1,330 @@
+import CrawlBarCore
+import Foundation
+
+extension CrawlBarSelfTest {
+    static func testNativeConfigEnvironment() throws {
+        try Self.testInheritedNativeSelection()
+        try Self.testInheritedNativeRetry()
+        try Self.testNativeSelectorPrecedence()
+        try Self.testNativeSelectorPresence()
+        try Self.testNativeLiteralSelectors()
+        try Self.testNativeFrozenEnvironment()
+    }
+
+    private static func testInheritedNativeSelection() throws {
+        for changed in [false, true] {
+            let fixture = try NativeEnvironmentFixture(change: changed ? "changed" : "unchanged", defaultValue: changed ? "A" : "B")
+            defer { try? FileManager.default.removeItem(at: fixture.directory) }
+            let runner = fixture.runner(selector: fixture.selectedURL.path)
+            try fixture.expectInitial(runner: runner, denied: changed)
+            try Self.expect(try Data(contentsOf: fixture.selectedURL) == NativeEnvironmentFixture.native(changed ? "B" : "A"), "only the inherited selected file changes")
+            try fixture.expectUnchanged()
+        }
+    }
+
+    private static func testInheritedNativeRetry() throws {
+        for changed in [false, true] {
+            let fixture = try NativeEnvironmentFixture(change: "retry")
+            defer { try? FileManager.default.removeItem(at: fixture.directory) }
+            let runner = fixture.runner(selector: fixture.selectedURL.path)
+            let coordinator = CrawlActionCoordinator()
+            let now = Date()
+            let first = try fixture.run(coordinator, runner: runner, now: now)
+            try Self.expect(first.results.map(\.action) == ["pull", "share"] && first.results.map(\.exitCode) == [0, 7] && first.failure != nil, "real publication fails once after successful sync")
+            let successfulSync = coordinator.lastSuccessfulSync(fixture.app.id)
+            try Self.expect(successfulSync == first.results.first?.finishedAt, "retry records actual successful sync time")
+            try Self.expect(try fixture.marker("sync") == "sync\n" && fixture.marker("publish") == "A\n", "first attempt invokes both real children")
+            if changed { try NativeEnvironmentFixture.write(NativeEnvironmentFixture.native("B"), to: fixture.selectedURL) }
+            let retry = try fixture.run(coordinator, runner: runner, now: now.addingTimeInterval(900), interval: 900)
+            try Self.expect(retry.failure == nil && retry.results.map(\.action) == (changed ? [] : ["share"]), "due retry is share-only success or guard denial without child error")
+            try Self.expect(try fixture.marker("sync") == "sync\n" && fixture.marker("publish") == (changed ? "A\n" : "A\nA\n"), "retry does not resync or invoke a denied publisher")
+            try Self.expect(coordinator.lastSuccessfulSync(fixture.app.id) == successfulSync, "retry preserves successful sync time")
+            try Self.expect(try Data(contentsOf: fixture.selectedURL) == NativeEnvironmentFixture.native(changed ? "B" : "A"), "retry does not rewrite selected config")
+            try fixture.expectUnchanged()
+        }
+    }
+
+    private static func testNativeSelectorPrecedence() throws {
+        for variant in ["explicit", "option", "option-changed", "blank"] {
+            var fixture = try NativeEnvironmentFixture(change: variant == "option-changed" ? "changed" : "unchanged")
+            defer { try? FileManager.default.removeItem(at: fixture.directory) }
+            var inherited = fixture.otherURL.path
+            switch variant {
+            case "explicit":
+                fixture.installation.configPathOverride = "  \(fixture.selectedURL.path) \n"
+            case "option", "option-changed":
+                fixture.installation.configPathOverride = fixture.otherURL.path
+                fixture.values["selector_first"] = fixture.otherURL.path
+                fixture.values["selector_last"] = " \(fixture.selectedURL.path) "
+                fixture.values["selector_blank"] = " \n"
+            default:
+                fixture.installation.configPathOverride = " \n"
+                fixture.values["selector_first"] = " \n"
+                inherited = fixture.selectedURL.path
+            }
+            let runner = fixture.runner(selector: inherited)
+            try fixture.expectProbe(runner: runner, selector: fixture.selectedURL.path)
+            try fixture.expectInitial(runner: runner, denied: variant == "option-changed")
+            try Self.expect(try Data(contentsOf: fixture.selectedURL) == NativeEnvironmentFixture.native(variant == "option-changed" ? "B" : "A"), "precedence selects only the intended file")
+            try fixture.expectUnchanged()
+        }
+    }
+
+    private static func testNativeSelectorPresence() throws {
+        for noConfigEnv in [false, true] {
+            var fixture = try NativeEnvironmentFixture()
+            defer { try? FileManager.default.removeItem(at: fixture.directory) }
+            if noConfigEnv {
+                fixture.installation.manifest.paths.configEnv = nil
+                fixture.installation.configPathOverride = fixture.defaultURL.path
+            }
+            let runner = fixture.runner(selector: nil)
+            try fixture.expectProbe(runner: runner, selector: nil)
+            try fixture.expectInitial(runner: runner, denied: false)
+            try fixture.expectUnchanged()
+        }
+        for selector in ["", " \t "] {
+            let fixture = try NativeEnvironmentFixture()
+            defer { try? FileManager.default.removeItem(at: fixture.directory) }
+            let runner = fixture.runner(selector: selector)
+            // Probe presence/bytes without trying to open an empty filename.
+            try fixture.expectProbe(runner: runner, selector: selector)
+            try Self.expect(!FileManager.default.fileExists(atPath: selector), "blank selector has no literal file before guard evaluation")
+            let permit = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: fixture.values, runner: runner)
+            try Self.expect(!permit(), "present empty or unreadable literal selector does not fall back to readable A")
+            try Self.expect(!FileManager.default.fileExists(atPath: fixture.home.appendingPathComponent("publish.marker").path), "direct denial never launches a publisher")
+            try fixture.expectUnchanged()
+        }
+    }
+
+    private static func testNativeLiteralSelectors() throws {
+        let fixture = try NativeEnvironmentFixture(defaultValue: "B")
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let literal = fixture.directory.appendingPathComponent(" selected.toml ")
+        try NativeEnvironmentFixture.write(NativeEnvironmentFixture.native("A"), to: literal)
+        try NativeEnvironmentFixture.write(NativeEnvironmentFixture.native("B"), to: fixture.selectedURL)
+        let runner = fixture.runner(selector: literal.path)
+        try fixture.expectProbe(runner: runner, selector: literal.path)
+        try fixture.expectInitial(runner: runner, denied: false)
+        try Self.expect(try Data(contentsOf: literal) == NativeEnvironmentFixture.native("A") && Data(contentsOf: fixture.selectedURL) == NativeEnvironmentFixture.native("B"), "literal whitespace and trimmed counterexample stay distinct")
+        try fixture.expectUnchanged()
+
+        let fm = FileManager.default
+        let original = fm.currentDirectoryPath
+        defer {
+            precondition(fm.changeCurrentDirectoryPath(original) && fm.currentDirectoryPath == original, "fixture must restore the original cwd")
+        }
+        for relative in ["selected.toml", "~/selected.toml"] {
+            let relativeFixture = try NativeEnvironmentFixture(defaultValue: "B")
+            defer {
+                precondition(fm.changeCurrentDirectoryPath(original) && fm.currentDirectoryPath == original, "restore cwd before fixture cleanup")
+                try? fm.removeItem(at: relativeFixture.directory)
+            }
+            let cwd = relativeFixture.directory.appendingPathComponent("cwd")
+            try fm.createDirectory(at: cwd.appendingPathComponent("~"), withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+            try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: cwd.path)
+            let selected = cwd.appendingPathComponent(relative)
+            try NativeEnvironmentFixture.write(NativeEnvironmentFixture.native("A"), to: selected)
+            try Self.expect(fm.changeCurrentDirectoryPath(cwd.path), "relative fixture enters its owned cwd")
+            try Self.expect(fm.currentDirectoryPath == cwd.resolvingSymlinksInPath().path && fm.currentDirectoryPath != relativeFixture.home.path, "test cwd is the fixture directory, not runner HOME")
+            let relativeRunner = relativeFixture.runner(selector: relative)
+            try relativeFixture.expectProbe(runner: relativeRunner, selector: relative)
+            try relativeFixture.expectInitial(runner: relativeRunner, denied: false)
+            try Self.expect(try Data(contentsOf: selected) == NativeEnvironmentFixture.native("A"), "relative selector preserves selected bytes")
+            try relativeFixture.expectUnchanged()
+            try Self.expect(fm.changeCurrentDirectoryPath(original) && fm.currentDirectoryPath == original, "relative case restores cwd before cleanup")
+        }
+    }
+
+    private static func testNativeFrozenEnvironment() throws {
+        var fixture = try NativeEnvironmentFixture(defaultValue: "B")
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        var environment = fixture.environment(selector: fixture.otherURL.path)
+        environment["FIXTURE_VALUE"] = "before"
+        let runner = CrawlCommandRunner(environment: environment)
+        environment["NATIVE_CONFIG"] = fixture.defaultURL.path
+        environment["FIXTURE_VALUE"] = "after"
+        try fixture.expectProbe(runner: runner, selector: fixture.otherURL.path)
+        var values = fixture.values
+        values["selector_first"] = fixture.selectedURL.path
+        fixture.values = values
+        values["selector_first"] = fixture.otherURL.path
+        try fixture.expectProbe(runner: runner, selector: fixture.selectedURL.path)
+        try Self.expect(try fixture.marker("value") == "before" && environment["FIXTURE_VALUE"] == "after" && values != fixture.values, "runner and action inputs remain frozen after caller dictionary edits")
+        try fixture.expectInitial(runner: runner, denied: false)
+        try fixture.expectUnchanged()
+        fixture.values = ["destination": "A"]
+        fixture.installation.configPathOverride = "  ~/crawlbar-fixture-not-opened.toml \n"
+        // Transport comparison only: never open the expanded non-fixture path.
+        try fixture.expectProbe(runner: runner, selector: PathExpander.expandHome("~/crawlbar-fixture-not-opened.toml"))
+    }
+}
+
+private struct NativeEnvironmentFixture {
+    let directory: URL
+    let home: URL
+    let mainURL: URL
+    let defaultURL: URL
+    let selectedURL: URL
+    let otherURL: URL
+    let app: CrawlBarAppConfig
+    let registry: CrawlAppRegistry
+    let initialMain: Data
+    let initialDefault: Data
+    var installation: CrawlAppInstallation
+    var values: [String: String] = ["destination": "A"]
+
+    init(change: String = "unchanged", defaultValue: String = "A") throws {
+        let fm = FileManager.default
+        let directory = fm.temporaryDirectory.appendingPathComponent("crawlbar-configenv-\(UUID())")
+        try fm.createDirectory(at: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        var initialized = false
+        defer { if !initialized { try? fm.removeItem(at: directory) } }
+        let home = directory.appendingPathComponent("home")
+        let apps = directory.appendingPathComponent("apps")
+        for path in [home, apps] {
+            try fm.createDirectory(at: path, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        }
+        let main = directory.appendingPathComponent("config.json")
+        let defaultURL = directory.appendingPathComponent("default.toml")
+        let selected = directory.appendingPathComponent("selected.toml")
+        let other = directory.appendingPathComponent("other.toml")
+        let script = directory.appendingPathComponent("child.sh")
+        try Self.write(Data(Self.script.utf8), to: script)
+        try Self.write(Self.native(defaultValue), to: defaultURL)
+        try Self.write(Self.native("A"), to: selected)
+        try Self.write(Self.native("B"), to: other)
+        try Self.write(Self.native("B"), to: home.appendingPathComponent("next.toml"))
+        var specification = CrawlBarSelfTest.nativeFixtureManifest(commands: [
+            "pull": [script.path, "sync", change, defaultURL.path],
+            "share": [script.path, "publish", change, defaultURL.path],
+            "probe": [script.path, "probe"],
+        ], binary: "/bin/sh")
+        specification.paths = .init(defaultConfig: defaultURL.path, configEnv: "NATIVE_CONFIG")
+        specification.configOptions = [
+            .init(id: "destination", label: "Destination", configKey: "share.repo_path"),
+            .init(id: "selector_first", label: "First selector", envVar: "NATIVE_CONFIG"),
+            .init(id: "selector_last", label: "Last selector", envVar: "NATIVE_CONFIG"),
+            .init(id: "selector_blank", label: "Blank selector", defaultValue: "not-injected", envVar: "NATIVE_CONFIG"),
+        ]
+        try Self.write(try CrawlCoding.makeJSONEncoder().encode(specification), to: apps.appendingPathComponent("fixture.json"))
+        let app = CrawlBarAppConfig(
+            id: specification.id, binaryPath: "/bin/sh", preferredRefreshAction: "pull",
+            shareEnabled: true, shareAfterRefresh: true, preferredShareAction: "share", configValues: ["destination": "A"])
+        let config = CrawlBarConfig(manifestDirectories: [apps.path], apps: [app])
+        let catalog = CrawlManifestCatalog(scanCache: CrawlManifestScanCache())
+        guard let manifest = catalog.manifest(for: app.id, config: config) else {
+            throw SelfTestError.failed("config environment external manifest was not discovered")
+        }
+        try CrawlBarSelfTest.expect(manifest == specification && catalog.diagnostics(config: config).isEmpty, "external manifest retains ordered selectors and config-only destination")
+        let store = CrawlBarConfigStore(fileURL: main, cache: CrawlBarConfigCache())
+        try store.save(config)
+        let registry = CrawlAppRegistry(configStore: store, catalog: catalog, nativeConfigStore: CrawlNativeConfigStore(cache: CrawlNativeConfigCache()))
+        self.directory = directory
+        self.home = home
+        self.mainURL = main
+        self.defaultURL = defaultURL
+        self.selectedURL = selected
+        self.otherURL = other
+        self.app = app
+        self.registry = registry
+        self.installation = CrawlAppInstallation(manifest: manifest, binaryPath: "/bin/sh", configValues: app.configValues)
+        self.initialMain = try Data(contentsOf: main)
+        self.initialDefault = try Data(contentsOf: defaultURL)
+        initialized = true
+    }
+
+    func environment(selector: String?) -> [String: String] {
+        var result = ["HOME": self.home.path, "TMPDIR": self.directory.path, "PATH": "/usr/bin:/bin"]
+        result["NATIVE_CONFIG"] = selector
+        return result
+    }
+
+    func runner(selector: String?) -> CrawlCommandRunner {
+        CrawlCommandRunner(environment: self.environment(selector: selector))
+    }
+
+    func run(_ coordinator: CrawlActionCoordinator, runner: CrawlCommandRunner, now: Date = Date(), interval: TimeInterval? = nil) throws -> CrawlActionOutcome {
+        let installation = self.installation
+        let values = self.values
+        let permit = self.registry.nativePublicationGuard(for: installation, configValues: values, runner: runner)
+        var guardCalls = 0
+        let outcome = try coordinator.run(
+            installation: installation, config: self.app, configValues: values, action: "pull",
+            now: now, scheduledInterval: interval, allowShare: {
+                guardCalls += 1
+                return permit()
+            })
+        { action in
+            try runner.run(installation: installation, configValues: values, action: action, timeoutSeconds: 5)
+        }
+        try CrawlBarSelfTest.expect(guardCalls == 1, "automatic publication invokes the guard exactly once")
+        return outcome
+    }
+
+    func expectInitial(runner: CrawlCommandRunner, denied: Bool) throws {
+        let outcome = try self.run(CrawlActionCoordinator(), runner: runner)
+        try CrawlBarSelfTest.expect(outcome.failure == nil && outcome.results.map(\.action) == (denied ? ["pull"] : ["pull", "share"]), "selected-file outcome is success or guard denial, not a child error")
+        try CrawlBarSelfTest.expect(try self.marker("sync") == "sync\n" && self.marker("publish") == (denied ? "" : "A\n"), "real children obey native selection")
+        if denied {
+            try CrawlBarSelfTest.expect(!FileManager.default.fileExists(atPath: self.home.appendingPathComponent("publish.marker").path), "denied publisher never creates a marker")
+        }
+    }
+
+    func expectProbe(runner: CrawlCommandRunner, selector: String?) throws {
+        let result = try runner.run(installation: self.installation, configValues: self.values, action: "probe", timeoutSeconds: 5)
+        try CrawlBarSelfTest.expect(result.succeeded, "presence-only environment probe succeeds")
+        let expected = selector.map { "present\n" + $0 } ?? "absent\n"
+        try CrawlBarSelfTest.expect(try self.marker("probe") == expected, "child sees exact selector presence and bytes")
+    }
+
+    func marker(_ name: String) throws -> String {
+        let path = self.home.appendingPathComponent("\(name).marker")
+        guard FileManager.default.fileExists(atPath: path.path) else { return "" }
+        return try String(contentsOf: path, encoding: .utf8)
+    }
+
+    func expectUnchanged() throws {
+        try CrawlBarSelfTest.expect(try Data(contentsOf: self.mainURL) == self.initialMain && Data(contentsOf: self.defaultURL) == self.initialDefault && Data(contentsOf: self.otherURL) == Self.native("B"), "main/default/unselected bytes remain unchanged")
+    }
+
+    static func native(_ destination: String) -> Data {
+        Data("[share]\nrepo_path = \"\(destination)\"\n".utf8)
+    }
+
+    static func write(_ data: Data, to path: URL) throws {
+        guard FileManager.default.createFile(atPath: path.path, contents: data, attributes: [.posixPermissions: 0o600]) else {
+            throw SelfTestError.failed("could not create private config environment fixture")
+        }
+    }
+
+    private static let script = #"""
+    set -eu
+    umask 077
+    if [ "$1" = probe ]; then
+      if [ "${NATIVE_CONFIG+x}" = x ]; then
+        printf 'present\n%s' "$NATIVE_CONFIG" > "$HOME/probe.marker"
+      else
+        printf 'absent\n' > "$HOME/probe.marker"
+      fi
+      printf '%s' "${FIXTURE_VALUE-}" > "$HOME/value.marker"
+      exit 0
+    fi
+    selected=${NATIVE_CONFIG-"$3"}
+    case "$1" in
+      sync)
+        printf 'sync\n' >> "$HOME/sync.marker"
+        if [ "$2" = changed ]; then /bin/cp "$HOME/next.toml" "$selected"; fi
+        ;;
+      publish)
+        destination=$(/usr/bin/sed -n 's/^repo_path = "\(.*\)"$/\1/p' "$selected")
+        printf '%s\n' "$destination" >> "$HOME/publish.marker"
+        if [ "$2" = retry ] && [ ! -f "$HOME/failed.marker" ]; then
+          printf 'failed\n' > "$HOME/failed.marker"
+          exit 7
+        fi
+        ;;
+      *) exit 64 ;;
+    esac
+    """#
+}

--- a/Sources/CrawlBarSelfTest/SelfTestNativeConfigEnvironment.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestNativeConfigEnvironment.swift
@@ -126,14 +126,36 @@ extension CrawlBarSelfTest {
             let selected = cwd.appendingPathComponent(relative)
             try NativeEnvironmentFixture.write(NativeEnvironmentFixture.native("A"), to: selected)
             try Self.expect(fm.changeCurrentDirectoryPath(cwd.path), "relative fixture enters its owned cwd")
-            try Self.expect(fm.currentDirectoryPath == cwd.resolvingSymlinksInPath().path && fm.currentDirectoryPath != relativeFixture.home.path, "test cwd is the fixture directory, not runner HOME")
+            let entered = fm.currentDirectoryPath
+            let actual = try Self.fixtureDirectoryIdentity(atPath: entered)
+            let requested = try Self.fixtureDirectoryIdentity(atPath: cwd.path)
+            let home = try Self.fixtureDirectoryIdentity(atPath: relativeFixture.home.path)
+            let matches = actual.device.isEqual(to: requested.device) && actual.inode.isEqual(to: requested.inode)
+            let distinct = !actual.device.isEqual(to: home.device) || !actual.inode.isEqual(to: home.inode)
+            try Self.expect(matches, "owned cwd identity matches: \(matches)")
+            try Self.expect(distinct, "runner HOME identity is distinct: \(distinct)")
             let relativeRunner = relativeFixture.runner(selector: relative)
+            try Self.expect(fm.currentDirectoryPath == entered, "raw cwd is stable before relative execution")
             try relativeFixture.expectProbe(runner: relativeRunner, selector: relative)
             try relativeFixture.expectInitial(runner: relativeRunner, denied: false)
+            try Self.expect(fm.currentDirectoryPath == entered, "raw cwd is stable after relative execution")
             try Self.expect(try Data(contentsOf: selected) == NativeEnvironmentFixture.native("A"), "relative selector preserves selected bytes")
             try relativeFixture.expectUnchanged()
             try Self.expect(fm.changeCurrentDirectoryPath(original) && fm.currentDirectoryPath == original, "relative case restores cwd before cleanup")
         }
+    }
+
+    private static func fixtureDirectoryIdentity(atPath path: String) throws -> (device: NSNumber, inode: NSNumber) {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path) else {
+            throw SelfTestError.failed("directory attributes readable: false")
+        }
+        let directory = (attributes[.type] as? FileAttributeType) == .typeDirectory
+        let device = attributes[.systemNumber] as? NSNumber
+        let inode = attributes[.systemFileNumber] as? NSNumber
+        guard directory, let device, let inode else {
+            throw SelfTestError.failed("directory identity available: directory=\(directory), device=\(device != nil), inode=\(inode != nil)")
+        }
+        return (device, inode)
     }
 
     private static func testNativeFrozenEnvironment() throws {

--- a/Sources/CrawlBarSelfTest/SelfTestNativePublicationGuard.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestNativePublicationGuard.swift
@@ -8,7 +8,7 @@ extension CrawlBarSelfTest {
             defer { try? FileManager.default.removeItem(at: fixture.directory) }
             let coordinator = CrawlActionCoordinator()
             let baseline = fixture.registry.appConfigWithNativeValues(fixture.app, manifest: fixture.manifest, includeSecrets: false)
-            let permit = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: fixture.values)
+            let permit = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: fixture.values, runner: fixture.runner)
             let outcome = try coordinator.run(
                 installation: fixture.installation, config: baseline, configValues: fixture.values, action: "pull",
                 allowShare: {
@@ -64,6 +64,7 @@ extension CrawlBarSelfTest {
         }
         try Self.testNativePublicationRetry()
         try Self.testNativePublicationMissingValues()
+        try Self.testNativeConfigEnvironment()
     }
 
     private static func testNativePublicationRetry() throws {
@@ -71,7 +72,7 @@ extension CrawlBarSelfTest {
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
         let coordinator = CrawlActionCoordinator()
         let now = Date()
-        let permit = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: fixture.values)
+        let permit = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: fixture.values, runner: fixture.runner)
         let first = try coordinator.run(
             installation: fixture.installation, config: fixture.app, configValues: fixture.values, action: "pull", now: now,
             allowShare: {
@@ -88,7 +89,7 @@ extension CrawlBarSelfTest {
         try fixture.nextNative.write(to: fixture.nativeURL)
         let retryValues = fixture.registry.appConfigWithNativeValues(fixture.app, manifest: fixture.manifest, includeSecrets: false).configValues
         try Self.expect(retryValues == fixture.values, "retry command inputs still contain saved A")
-        let retryPermit = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: retryValues)
+        let retryPermit = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: retryValues, runner: fixture.runner)
         let retry = try coordinator.run(
             installation: fixture.installation, config: fixture.app, configValues: retryValues,
             action: "pull", now: now.addingTimeInterval(900), scheduledInterval: 900,
@@ -109,7 +110,7 @@ extension CrawlBarSelfTest {
     private static func testNativePublicationMissingValues() throws {
         let fixture = try NativePublicationFixture(change: "unchanged", destination: nil)
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        let absent = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: [:])
+        let absent = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: [:], runner: fixture.runner)
         try Self.expect(absent(), "readable absent/absent ignores manifest default A")
         let coordinator = CrawlActionCoordinator()
         let baseline = fixture.registry.appConfigWithNativeValues(fixture.app, manifest: fixture.manifest, includeSecrets: false)
@@ -121,12 +122,12 @@ extension CrawlBarSelfTest {
         }
         try Self.expect(outcome.failure == nil && outcome.results.map(\.action) == ["pull", "share"], "absent values keep the child runnable")
         try Self.expect(try fixture.marker("publish") == "child-default\n", "child default is not replaced by manifest default")
-        let expectedA = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: ["destination": "A"])
+        let expectedA = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: ["destination": "A"], runner: fixture.runner)
         try Self.expect(!expectedA(), "saved A versus absent native is denied despite default A")
         try Data("[share]\nrepo_path = \"A\"\n".utf8).write(to: fixture.nativeURL)
         try Self.expect(!absent() && expectedA(), "absent/A differs and A/A matches")
         try FileManager.default.removeItem(at: fixture.nativeURL)
-        let lazy = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: ["destination": "A"])
+        let lazy = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: ["destination": "A"], runner: fixture.runner)
         try Data("[share]\nrepo_path = \"A\"\n".utf8).write(to: fixture.nativeURL)
         try Self.expect(lazy(), "factory reads only when its returned guard is invoked")
         try FileManager.default.removeItem(at: fixture.nativeURL)
@@ -143,14 +144,14 @@ extension CrawlBarSelfTest {
             .init(id: "env", label: "Environment", envVar: "PUBLICATION_FIXTURE_VALUE", configKey: "share.repo_path"),
             .init(id: "fixture_secret", label: "Fixture secret", kind: .secret, configKey: "auth.fixture"),
         ]
-        try Self.expect(fixture.registry.nativePublicationGuard(for: noMapping, configValues: [:])(), "env-backed and secret mappings require no added file read")
+        try Self.expect(fixture.registry.nativePublicationGuard(for: noMapping, configValues: [:], runner: fixture.runner)(), "env-backed and secret mappings require no added file read")
         var unavailable = fixture.installation
         unavailable.configPathOverride = nil
         unavailable.manifest.paths.defaultConfig = nil
-        try Self.expect(!fixture.registry.nativePublicationGuard(for: unavailable, configValues: [:])(), "selected route without a path is denied")
+        try Self.expect(!fixture.registry.nativePublicationGuard(for: unavailable, configValues: [:], runner: fixture.runner)(), "selected route without a path is denied")
         var remote = fixture.installation
         remote.manifest.execution = .init(kind: .ssh)
-        try Self.expect(fixture.registry.nativePublicationGuard(for: remote, configValues: [:])(), "remote predicate performs no local file probe")
+        try Self.expect(fixture.registry.nativePublicationGuard(for: remote, configValues: [:], runner: fixture.runner)(), "remote predicate performs no local file probe")
     }
 }
 

--- a/Sources/CrawlBarSelfTest/SelfTestNativePublicationGuard.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestNativePublicationGuard.swift
@@ -1,0 +1,289 @@
+import CrawlBarCore
+import Foundation
+
+extension CrawlBarSelfTest {
+    static func testNativePublicationGuard() throws {
+        for change in ["unchanged", "changed", "same-mtime", "secret-only", "missing", "invalid-utf8"] {
+            let fixture = try NativePublicationFixture(change: change)
+            defer { try? FileManager.default.removeItem(at: fixture.directory) }
+            let coordinator = CrawlActionCoordinator()
+            let baseline = fixture.registry.appConfigWithNativeValues(fixture.app, manifest: fixture.manifest, includeSecrets: false)
+            let permit = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: fixture.values)
+            let outcome = try coordinator.run(
+                installation: fixture.installation, config: baseline, configValues: fixture.values, action: "pull",
+                allowShare: {
+                    fixture.registry.matchesPersistedAppConfig(baseline, manifest: fixture.manifest) && permit()
+                })
+            { action in
+                let result = try fixture.runner.run(
+                    installation: fixture.installation, configValues: fixture.values, action: action, timeoutSeconds: 5)
+                if action == "pull", change == "same-mtime" {
+                    try FileManager.default.setAttributes([.modificationDate: fixture.modificationDate], ofItemAtPath: fixture.nativeURL.path)
+                    try Self.expect(try fixture.nativeModificationDate() == fixture.modificationDate, "native overwrite restores the exact primed mtime")
+                }
+                return result
+            }
+            let publish = change == "unchanged" || change == "secret-only"
+            try Self.expect(outcome.failure == nil, "native publication fixture \(change) has no action error")
+            try Self.expect(outcome.results.map(\.action) == (publish ? ["pull", "share"] : ["pull"]), "native publication phases \(change)")
+            try Self.expect(try fixture.marker("sync") == "sync\n", "real sync ran exactly once for \(change)")
+            try Self.expect(try fixture.marker("publish") == (publish ? "A\n" : ""), "real publisher invocation for \(change)")
+            if !publish {
+                try Self.expect(!FileManager.default.fileExists(atPath: fixture.directory.appendingPathComponent("publish.marker").path), "denied publisher created no marker")
+            }
+            try fixture.expectMainUnchanged()
+            if change == "missing" {
+                try Self.expect(!FileManager.default.fileExists(atPath: fixture.nativeURL.path), "missing native config is not recreated")
+            } else {
+                let native = try Data(contentsOf: fixture.nativeURL)
+                let expected = change == "unchanged" ? fixture.initialNative : fixture.nextNative
+                try Self.expect(native == expected, "guard preserves exact native bytes for \(change)")
+                if change == "same-mtime" {
+                    try Self.expect(native != fixture.initialNative, "same-mtime fixture changed native bytes")
+                    try Self.expect(try fixture.nativeModificationDate() == fixture.modificationDate, "guard preserves native mtime")
+                }
+            }
+            if change == "changed" {
+                let current = try fixture.nativeStore.read(path: fixture.nativeURL.path, manifest: fixture.manifest)
+                try Self.expect(current["destination"] == "B" && fixture.values == ["destination": "A"], "persisted A cannot mask native B")
+                try Self.expect(!permit(), "changed native state is denied before standalone control")
+                var guardCalls = 0
+                let standalone = try coordinator.run(
+                    installation: fixture.installation, config: baseline, configValues: fixture.values, action: "share",
+                    allowShare: {
+                        guardCalls += 1
+                        return permit()
+                    })
+                { action in
+                    try fixture.runner.run(
+                        installation: fixture.installation, configValues: fixture.values, action: action, timeoutSeconds: 5)
+                }
+                try Self.expect(standalone.failure == nil && standalone.results.map(\.action) == ["share"], "standalone share still runs")
+                try Self.expect(guardCalls == 0 && (try fixture.marker("publish")) == "B\n", "standalone share bypasses the between-phase hook")
+            }
+        }
+        try Self.testNativePublicationRetry()
+        try Self.testNativePublicationMissingValues()
+    }
+
+    private static func testNativePublicationRetry() throws {
+        let fixture = try NativePublicationFixture(change: "retry")
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let coordinator = CrawlActionCoordinator()
+        let now = Date()
+        let permit = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: fixture.values)
+        let first = try coordinator.run(
+            installation: fixture.installation, config: fixture.app, configValues: fixture.values, action: "pull", now: now,
+            allowShare: {
+                (try? fixture.registry.loadConfig().apps.first { $0.id == fixture.app.id }) == fixture.app && permit()
+            })
+        { action in
+            try fixture.runner.run(
+                installation: fixture.installation, configValues: fixture.values, action: action, timeoutSeconds: 5)
+        }
+        try Self.expect(first.results.map(\.action) == ["pull", "share"] && first.results.map(\.exitCode) == [0, 7] && first.failure != nil, "real first publication fails only after sync")
+        let successfulSync = coordinator.lastSuccessfulSync(fixture.app.id)
+        try Self.expect(successfulSync == first.results.first?.finishedAt, "successful sync retained after failed publisher")
+        try Self.expect(try fixture.marker("sync") == "sync\n" && fixture.marker("publish") == "A\n", "failed real publisher recorded A")
+        try fixture.nextNative.write(to: fixture.nativeURL)
+        let retryValues = fixture.registry.appConfigWithNativeValues(fixture.app, manifest: fixture.manifest, includeSecrets: false).configValues
+        try Self.expect(retryValues == fixture.values, "retry command inputs still contain saved A")
+        let retryPermit = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: retryValues)
+        let retry = try coordinator.run(
+            installation: fixture.installation, config: fixture.app, configValues: retryValues,
+            action: "pull", now: now.addingTimeInterval(900), scheduledInterval: 900,
+            allowShare: {
+                (try? fixture.registry.loadConfig().apps.first { $0.id == fixture.app.id }) == fixture.app && retryPermit()
+            })
+        { action in
+            try fixture.runner.run(
+                installation: fixture.installation, configValues: retryValues, action: action, timeoutSeconds: 5)
+        }
+        try Self.expect(retry.results.isEmpty && retry.failure == nil, "menu-shaped retry is authorization denial, not a child error")
+        try Self.expect(try fixture.marker("sync") == "sync\n" && fixture.marker("publish") == "A\n", "denied retry neither resyncs nor invokes publisher")
+        try Self.expect(coordinator.lastSuccessfulSync(fixture.app.id) == successfulSync, "denied retry preserves successful sync time")
+        try Self.expect(try Data(contentsOf: fixture.nativeURL) == fixture.nextNative, "retry leaves native B intact")
+        try fixture.expectMainUnchanged()
+    }
+
+    private static func testNativePublicationMissingValues() throws {
+        let fixture = try NativePublicationFixture(change: "unchanged", destination: nil)
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let absent = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: [:])
+        try Self.expect(absent(), "readable absent/absent ignores manifest default A")
+        let coordinator = CrawlActionCoordinator()
+        let baseline = fixture.registry.appConfigWithNativeValues(fixture.app, manifest: fixture.manifest, includeSecrets: false)
+        let outcome = try coordinator.run(
+            installation: fixture.installation, config: baseline, configValues: [:], action: "pull",
+            allowShare: { fixture.registry.matchesPersistedAppConfig(baseline, manifest: fixture.manifest) && absent() })
+        { action in
+            try fixture.runner.run(installation: fixture.installation, configValues: [:], action: action, timeoutSeconds: 5)
+        }
+        try Self.expect(outcome.failure == nil && outcome.results.map(\.action) == ["pull", "share"], "absent values keep the child runnable")
+        try Self.expect(try fixture.marker("publish") == "child-default\n", "child default is not replaced by manifest default")
+        let expectedA = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: ["destination": "A"])
+        try Self.expect(!expectedA(), "saved A versus absent native is denied despite default A")
+        try Data("[share]\nrepo_path = \"A\"\n".utf8).write(to: fixture.nativeURL)
+        try Self.expect(!absent() && expectedA(), "absent/A differs and A/A matches")
+        try FileManager.default.removeItem(at: fixture.nativeURL)
+        let lazy = fixture.registry.nativePublicationGuard(for: fixture.installation, configValues: ["destination": "A"])
+        try Data("[share]\nrepo_path = \"A\"\n".utf8).write(to: fixture.nativeURL)
+        try Self.expect(lazy(), "factory reads only when its returned guard is invoked")
+        try FileManager.default.removeItem(at: fixture.nativeURL)
+        try Self.expect(!absent() && !expectedA(), "missing selected config is not readable absence")
+        try Data([0xff, 0xfe, 0xff]).write(to: fixture.nativeURL)
+        try Self.expect(!absent() && !expectedA(), "invalid UTF-8 is refused")
+        try Self.expect(try Data(contentsOf: fixture.nativeURL) == Data([0xff, 0xfe, 0xff]), "invalid bytes are not repaired")
+        try FileManager.default.removeItem(at: fixture.nativeURL)
+        try FileManager.default.createDirectory(at: fixture.nativeURL, withIntermediateDirectories: false)
+        try Self.expect(!absent(), "selected config read errors are refused")
+        try FileManager.default.removeItem(at: fixture.nativeURL)
+        var noMapping = fixture.installation
+        noMapping.manifest.configOptions = [
+            .init(id: "env", label: "Environment", envVar: "PUBLICATION_FIXTURE_VALUE", configKey: "share.repo_path"),
+            .init(id: "fixture_secret", label: "Fixture secret", kind: .secret, configKey: "auth.fixture"),
+        ]
+        try Self.expect(fixture.registry.nativePublicationGuard(for: noMapping, configValues: [:])(), "env-backed and secret mappings require no added file read")
+        var unavailable = fixture.installation
+        unavailable.configPathOverride = nil
+        unavailable.manifest.paths.defaultConfig = nil
+        try Self.expect(!fixture.registry.nativePublicationGuard(for: unavailable, configValues: [:])(), "selected route without a path is denied")
+        var remote = fixture.installation
+        remote.manifest.execution = .init(kind: .ssh)
+        try Self.expect(fixture.registry.nativePublicationGuard(for: remote, configValues: [:])(), "remote predicate performs no local file probe")
+    }
+}
+
+private struct NativePublicationFixture {
+    let directory: URL
+    let nativeURL: URL
+    let mainURL: URL
+    let manifest: CrawlAppManifest
+    let app: CrawlBarAppConfig
+    let registry: CrawlAppRegistry
+    let nativeStore: CrawlNativeConfigStore
+    let installation: CrawlAppInstallation
+    let values: [String: String]
+    let runner: CrawlCommandRunner
+    let initialMain: Data
+    let initialNative: Data
+    let nextNative: Data
+    let modificationDate: Date
+
+    init(change: String, destination: String? = "A") throws {
+        let fm = FileManager.default
+        let directory = fm.temporaryDirectory.appendingPathComponent("crawlbar-native-publication-\(UUID())")
+        let appsURL = directory.appendingPathComponent("apps")
+        try fm.createDirectory(at: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        try fm.createDirectory(at: appsURL, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let nativeURL = directory.appendingPathComponent("native.toml")
+        let mainURL = directory.appendingPathComponent("config.json")
+        let scriptURL = directory.appendingPathComponent("child.sh")
+        try Self.script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        var specification = CrawlBarSelfTest.nativeFixtureManifest(commands: [
+            "pull": [scriptURL.path, "sync", change], "share": [scriptURL.path, "publish", change],
+        ], binary: "/bin/sh")
+        specification.paths = .init(defaultConfig: nativeURL.path, configEnv: "NATIVE_PUBLICATION_CONFIG")
+        specification.configOptions = [
+            .init(id: "destination", label: "Destination", defaultValue: "A", configKey: "share.repo_path"),
+            .init(id: "fixture_secret", label: "Fixture secret", kind: .secret, configKey: "auth.fixture"),
+        ]
+        try CrawlCoding.makeJSONEncoder().encode(specification).write(to: appsURL.appendingPathComponent("fixture.json"))
+        let app = CrawlBarAppConfig(
+            id: specification.id, binaryPath: "/bin/sh", configPath: nativeURL.path,
+            preferredRefreshAction: "pull", shareEnabled: true, shareAfterRefresh: true, preferredShareAction: "share",
+            configValues: destination.map { ["destination": $0] } ?? [:])
+        let config = CrawlBarConfig(manifestDirectories: [appsURL.path], apps: [app])
+        let catalog = CrawlManifestCatalog(scanCache: CrawlManifestScanCache())
+        guard let manifest = catalog.manifest(for: app.id, config: config) else {
+            throw SelfTestError.failed("external publication manifest was not discovered")
+        }
+        try CrawlBarSelfTest.expect(
+            catalog.diagnostics(config: config).isEmpty && manifest == specification
+                && manifest.configOptions[0].envVar == nil && manifest.configOptions[0].configKey == "share.repo_path",
+            "decoded external manifest retains config-only destination and fixed child commands")
+        let store = CrawlBarConfigStore(fileURL: mainURL, cache: CrawlBarConfigCache())
+        let nativeStore = CrawlNativeConfigStore(cache: CrawlNativeConfigCache())
+        let registry = CrawlAppRegistry(configStore: store, catalog: catalog, nativeConfigStore: nativeStore)
+        try store.save(config)
+        var nativeApp = app
+        nativeApp.configValues["fixture_secret"] = UUID().uuidString
+        try nativeStore.write(appConfig: nativeApp, manifest: manifest)
+        let initialNative = try Data(contentsOf: nativeURL)
+        let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
+        try fm.setAttributes([.modificationDate: fixedDate], ofItemAtPath: nativeURL.path)
+        let attributes = try fm.attributesOfItem(atPath: nativeURL.path)
+        guard let date = attributes[.modificationDate] as? Date else { throw SelfTestError.failed("native fixture has no mtime") }
+        try CrawlBarSelfTest.expect(date == fixedDate, "native fixture establishes exact whole-second mtime before cache prime")
+        let values = registry.appConfigWithNativeValues(app, manifest: manifest, includeSecrets: false).configValues
+        let persisted = try store.load(includeSecrets: false)?.apps.first { $0.id == app.id }
+        let nativeValues = try nativeStore.read(path: nativeURL.path, manifest: manifest)
+        try CrawlBarSelfTest.expect(persisted == app && values == app.configValues && nativeValues["destination"] == destination, "main/native A and nonsecret command inputs agree before execution")
+        let nextNative: Data
+        if change == "invalid-utf8" {
+            nextNative = Data([0xff, 0xfe, 0xff])
+        } else if change == "secret-only" {
+            let nextURL = directory.appendingPathComponent("next-secret.toml")
+            var next = nativeApp
+            next.configPath = nextURL.path
+            next.configValues["fixture_secret"] = UUID().uuidString
+            try nativeStore.write(appConfig: next, manifest: manifest)
+            nextNative = try Data(contentsOf: nextURL)
+        } else {
+            nextNative = Data("[share]\nrepo_path = \"B\"\n".utf8)
+        }
+        try nextNative.write(to: directory.appendingPathComponent("native-next.toml"))
+        self.directory = directory
+        self.nativeURL = nativeURL
+        self.mainURL = mainURL
+        self.manifest = manifest
+        self.app = app
+        self.registry = registry
+        self.nativeStore = nativeStore
+        self.values = values
+        self.installation = CrawlAppInstallation(
+            manifest: manifest, binaryPath: "/bin/sh", configPathOverride: nativeURL.path, configValues: values)
+        self.runner = CrawlCommandRunner(environment: ["HOME": directory.path, "TMPDIR": directory.path, "PATH": "/usr/bin:/bin"])
+        self.initialMain = try Data(contentsOf: mainURL)
+        self.initialNative = initialNative
+        self.nextNative = nextNative
+        self.modificationDate = date
+    }
+
+    func marker(_ name: String) throws -> String {
+        let url = self.directory.appendingPathComponent("\(name).marker")
+        guard FileManager.default.fileExists(atPath: url.path) else { return "" }
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    func nativeModificationDate() throws -> Date? {
+        try FileManager.default.attributesOfItem(atPath: self.nativeURL.path)[.modificationDate] as? Date
+    }
+
+    func expectMainUnchanged() throws {
+        try CrawlBarSelfTest.expect(try Data(contentsOf: self.mainURL) == self.initialMain, "main config bytes remain unchanged")
+    }
+
+    private static let script = #"""
+    set -eu
+    case "$1" in
+      sync)
+        printf 'sync\n' >> "$HOME/sync.marker"
+        case "$2" in
+          changed|same-mtime|secret-only|invalid-utf8) /bin/cp "$HOME/native-next.toml" "$NATIVE_PUBLICATION_CONFIG" ;;
+          missing) /bin/rm "$NATIVE_PUBLICATION_CONFIG" ;;
+        esac
+        ;;
+      publish)
+        destination=child-default
+        if [ -f "$NATIVE_PUBLICATION_CONFIG" ]; then
+          observed=$(/usr/bin/sed -n 's/^repo_path = "\(.*\)"$/\1/p' "$NATIVE_PUBLICATION_CONFIG")
+          if [ -n "$observed" ]; then destination=$observed; fi
+        fi
+        printf '%s\n' "$destination" >> "$HOME/publish.marker"
+        if [ "$2" = retry ]; then exit 7; fi
+        ;;
+      *) exit 64 ;;
+    esac
+    """#
+}

--- a/Sources/CrawlBarSelfTest/SelfTestNativeSafety.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestNativeSafety.swift
@@ -1,0 +1,141 @@
+import CrawlBarCore
+import Foundation
+
+extension CrawlBarSelfTest {
+    static func testNativeArchiveMappingAndBackupSelection() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("crawlbar-source-safety-\(UUID())")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = directory.appendingPathComponent("source.db")
+        let archive = directory.appendingPathComponent("archive.db")
+        try Data("synthetic source".utf8).write(to: source)
+        try Data("synthetic archive".utf8).write(to: archive)
+        let payload: [String: Any] = [
+            "schema_version": "crawlkit.control.v1", "state": "ok",
+            "source": ["database_path": source.path, "database_bytes": 999],
+            "archive": ["archive_path": archive.path, "archive_bytes": 17],
+        ]
+        let status = CrawlStatusMapper().status(
+            from: try Self.nativeStatusResult(payload, appID: BuiltInCrawlApps.imsgcrawlID),
+            manifest: BuiltInCrawlApps.imsgcrawl)
+        try Self.expect(status.databasePath == archive.path, "imsg archive path wins over source database_path")
+        try Self.expect(status.databaseBytes == 17, "imsg archive byte count is not the source count")
+        try Self.expect(status.databases.count == 1 && status.databases[0].path == archive.path, "inventory contains only the archive")
+
+        let capture = directory.appendingPathComponent("backup-source.txt")
+        let sqlite = directory.appendingPathComponent("sqlite3")
+        let quoted = "'" + capture.path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        try Data("#!/bin/sh\nprintf '%s' \"$1\" > \(quoted)\ncat >/dev/null\n".utf8).write(to: sqlite)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: sqlite.path)
+        let resolver = CrawlExecutableResolver(environment: ["HOME": directory.path, "PATH": directory.path + ":/usr/bin:/bin"])
+        let backup = try CrawlDatabaseBackupStore.backup(
+            status: status, root: directory.appendingPathComponent("backups"),
+            resolver: resolver, sqliteProcessTimeout: 5)
+        try Self.expect(backup.files.count == 1, "backup selects one archive resource")
+        let selected = try String(contentsOf: capture, encoding: .utf8)
+        try Self.expect(selected == archive.path, "actual backup invocation never receives the source database")
+        let sourceBytes = try Data(contentsOf: source)
+        try Self.expect(sourceBytes == Data("synthetic source".utf8), "source bytes remain unchanged")
+        let missingArchivePayloads: [[String: Any]] = [
+            ["database_path": source.path],
+            ["db_path": source.path, "databases": [["id": "source", "kind": "sqlite", "path": source.path]]],
+            ["source": ["database_path": source.path], "archive": [:]],
+        ]
+        for missing in missingArchivePayloads {
+            let mapped = CrawlStatusMapper().status(
+                from: try Self.nativeStatusResult(missing, appID: BuiltInCrawlApps.imsgcrawlID),
+                manifest: BuiltInCrawlApps.imsgcrawl)
+            try Self.expect(mapped.databasePath == nil && mapped.databases.isEmpty, "missing imsg archive_path cannot infer any backup resource")
+        }
+    }
+
+    static func testNativeStatusFreshnessAndMissingState() throws {
+        let manifest = Self.nativeFixtureManifest(commands: ["status": ["status"]])
+        let old: [String: Any] = [
+            "schema_version": "crawlkit.control.v1", "state": "ready",
+            "generated_at": ISO8601DateFormatter().string(from: Date()),
+            "last_import_at": "2000-01-01T00:00:00Z",
+        ]
+        let status = CrawlStatusMapper().status(
+            from: try Self.nativeStatusResult(old, appID: manifest.id), manifest: manifest, staleAfterSeconds: 60)
+        try Self.expect(status.state == .current, "explicit readiness remains separate from freshness")
+        try Self.expect(status.freshness?.status == .stale, "fresh status output cannot refresh old imported data")
+        try Self.expect(status.lastSyncAt == nil && status.lastImportAt != nil, "import is not mislabeled as a sync")
+        let never = CrawlStatusMapper().status(
+            from: try Self.nativeStatusResult(["state": "ready", "generated_at": "2026-09-08T12:00:00Z"], appID: manifest.id),
+            manifest: manifest)
+        try Self.expect(never.lastSyncAt == nil && never.freshness == nil, "generated_at alone establishes no data freshness")
+        for (raw, expected) in [("missing", CrawlAppState.needsConfig), ("unrecognized-state", .unknown), ("ready", .current)] {
+            let mapped = CrawlStatusMapper().status(
+                from: try Self.nativeStatusResult(["state": raw], appID: manifest.id), manifest: manifest)
+            try Self.expect(mapped.state == expected, "external manifest state \(raw) maps truthfully")
+        }
+    }
+
+    static func testNativeRecursiveConfigExpansion() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("crawlbar-config-safety-\(UUID())")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        var manifest = Self.nativeFixtureManifest(commands: ["status": ["%s", "{config:first}"]], binary: "/usr/bin/printf")
+        manifest.configOptions = [.init(id: "third", label: "Third", defaultValue: "value")]
+        let runner = CrawlCommandRunner(environment: ["HOME": directory.path, "PATH": "/usr/bin:/bin"])
+        let installation = CrawlAppInstallation(manifest: manifest, binaryPath: "/usr/bin/printf")
+        let nested = try runner.run(
+            installation: installation,
+            configValues: ["first": "prefix-{config:second}", "second": "{config:third}"],
+            action: "status", timeoutSeconds: 5)
+        try Self.expect(nested.stdout == "prefix-value", "finite acyclic recursive interpolation is preserved")
+        let accountManifest = Self.nativeFixtureManifest(commands: ["status": ["%s", "--account", "{config:account}", "value"]])
+        let account = try runner.run(
+            installation: .init(manifest: accountManifest, binaryPath: "/usr/bin/printf"),
+            configValues: [:], action: "status", timeoutSeconds: 5)
+        try Self.expect(account.stdout == "value", "an omitted optional account retains existing argv behavior")
+        for values in [
+            ["first": "{config:first}"],
+            ["first": "{config:second}", "second": "{config:first}"],
+            ["first": "{config:first}x"],
+            ["first": String(repeating: "x", count: 1_048_577)],
+        ] {
+            do {
+                _ = try runner.run(installation: installation, configValues: values, action: "status", timeoutSeconds: 5)
+                throw SelfTestError.failed("unbounded config expansion accepted")
+            } catch CrawlCommandRunnerError.invalidConfigExpansion {
+            }
+        }
+    }
+
+    static func testExistingCredentialFixOnFailureLogs() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("crawlbar-existing-redaction-\(UUID())")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let script = directory.appendingPathComponent("fixture")
+        try Data("#!/bin/sh\nprintf '%s' \"$CRAWLBAR_FIXTURE_SECRET\"\nprintf '%s' \"$CRAWLBAR_FIXTURE_SECRET\" >&2\nexit 7\n".utf8).write(to: script)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: script.path)
+        var manifest = Self.nativeFixtureManifest(commands: ["status": []], binary: script.path)
+        manifest.configOptions = [.init(id: "fixture", label: "Fixture", kind: .secret, envVar: "CRAWLBAR_FIXTURE_SECRET")]
+        let installation = CrawlAppInstallation(manifest: manifest, binaryPath: script.path)
+        let synthetic = "opaque-" + UUID().uuidString
+        let result = try CrawlCommandRunner(environment: ["HOME": directory.path, "PATH": "/usr/bin:/bin"]).run(
+            installation: installation, configValues: ["fixture": synthetic], action: "status", timeoutSeconds: 5)
+        try Self.expect(result.exitCode == 7 && result.stdout == "[REDACTED]" && result.stderr == "[REDACTED]", "existing exact-value redaction covers both failure streams")
+        let log = try CrawlActionLogStore(directoryURL: directory.appendingPathComponent("logs")).save(result)
+        let persisted = try String(contentsOf: log, encoding: .utf8)
+        try Self.expect(!persisted.contains(synthetic) && installation.configValues.isEmpty, "existing credential fix keeps installation and persisted result secret-free")
+    }
+
+    static func nativeFixtureManifest(commands: [String: [String]], binary: String = "/usr/bin/printf") -> CrawlAppManifest {
+        CrawlAppManifest(
+            id: CrawlAppID(rawValue: "native-fixture"), displayName: "Native Fixture",
+            description: "Synthetic control fixture", binary: .init(name: binary),
+            branding: .init(symbolName: "terminal", accentColor: "#123456"),
+            paths: .init(), commands: commands, capabilities: [.status])
+    }
+
+    static func nativeStatusResult(_ payload: [String: Any], appID: CrawlAppID) throws -> CrawlCommandResult {
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        return CrawlCommandResult(
+            appID: appID, action: "status", exitCode: 0,
+            stdout: String(decoding: data, as: UTF8.self), stderr: "",
+            startedAt: Date(), finishedAt: Date())
+    }
+}

--- a/Sources/CrawlBarSelfTest/SelfTestNativeSafety.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestNativeSafety.swift
@@ -65,9 +65,50 @@ extension CrawlBarSelfTest {
             from: try Self.nativeStatusResult(["state": "ready", "generated_at": "2026-09-08T12:00:00Z"], appID: manifest.id),
             manifest: manifest)
         try Self.expect(never.lastSyncAt == nil && never.freshness == nil, "generated_at alone establishes no data freshness")
+        let recent = Date()
+        let recentISO = ISO8601DateFormatter().string(from: recent)
+        let oldTimestamps: [Any] = ["2000-01-01T00:00:00Z", 946684800]
+        for timestamp in oldTimestamps {
+            for generated in [false, true] {
+                var payload: [String: Any] = ["state": "ready", "updated_at": timestamp]
+                if generated { payload["generated_at"] = recentISO }
+                let legacy = CrawlStatusMapper().status(
+                    from: try Self.nativeStatusResult(payload, appID: manifest.id), manifest: manifest, staleAfterSeconds: 60)
+                try Self.expect(legacy.freshness?.status == .stale && legacy.state == .current, "legacy updated_at preserves stale data separately from readiness")
+                try Self.expect(legacy.lastSyncAt == nil && legacy.lastImportAt == nil, "legacy data time is not relabeled as sync or import")
+            }
+        }
+        let recentTimestamps: [Any] = [recentISO, recent.timeIntervalSince1970]
+        for timestamp in recentTimestamps {
+            let legacy = CrawlStatusMapper().status(
+                from: try Self.nativeStatusResult(["updated_at": timestamp], appID: manifest.id),
+                manifest: manifest, staleAfterSeconds: 60)
+            try Self.expect(legacy.freshness?.status == .current, "recent legacy ISO or epoch data time is current")
+        }
+        let actualTimes: [[String: Any]] = [
+            ["last_sync_at": "2000-01-01T00:00:00Z"],
+            ["last_import_at": "2000-01-01T00:00:00Z"],
+            ["remote": ["mode": "fixture", "last_sync_at": "2000-01-01T00:00:00Z"]],
+            ["remote": ["mode": "fixture", "last_ingest_at": "2000-01-01T00:00:00Z"]],
+        ]
+        for actual in actualTimes {
+            var payload = actual
+            payload["updated_at"] = recentISO
+            let mapped = CrawlStatusMapper().status(
+                from: try Self.nativeStatusResult(payload, appID: manifest.id), manifest: manifest, staleAfterSeconds: 60)
+            try Self.expect(mapped.freshness?.status == .stale, "sync/import/remote times retain priority over legacy updated_at")
+        }
+        let explicit = CrawlStatusMapper().status(
+            from: try Self.nativeStatusResult([
+                "updated_at": "2000-01-01T00:00:00Z", "freshness": ["status": "current"],
+            ], appID: manifest.id), manifest: manifest)
+        try Self.expect(explicit.freshness?.status == .current, "explicit freshness retains priority over legacy data time")
+        let untimed = CrawlStatusMapper().status(
+            from: try Self.nativeStatusResult(["state": "ready"], appID: manifest.id), manifest: manifest)
+        try Self.expect(untimed.freshness == nil, "timestamp-free status does not invent freshness")
         for (raw, expected) in [("missing", CrawlAppState.needsConfig), ("unrecognized-state", .unknown), ("ready", .current)] {
             let mapped = CrawlStatusMapper().status(
-                from: try Self.nativeStatusResult(["state": raw], appID: manifest.id), manifest: manifest)
+                from: try Self.nativeStatusResult(["state": raw, "updated_at": recentISO], appID: manifest.id), manifest: manifest)
             try Self.expect(mapped.state == expected, "external manifest state \(raw) maps truthfully")
         }
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where iMessage status could make the Messages source database eligible for backup, fresh status output could make old archive data appear fresh, and crawler actions could overlap or repeat a successful sync after publication failed.

Settings sync could also skip publication with unchanged native settings or admit stale main-config values. Saved settings could mask a native destination change. For local crawlers using an environment-selected config file, the publication check could inspect the default file instead of the file selected for the child. These are conditional command/configuration paths, not evidence of an observed private upload.

## Why This Change Was Made

Keep backup inventory archive-only, derive freshness from data timestamps, and report missing archives explicitly. Coordinate actions per crawler, retain retry timing and sharing consent, and discard superseded status updates. Finite recursive configuration substitution stays supported; cycles and excessive expansion are bounded.

The Settings publication check compares equivalent nonsecret snapshots and reads main config without relying on its cached modification time. Settings and Menu also compare declared nonsecret config-only values against frozen execution inputs using an uncached native-file read. The native filename comes from the same runner and environment assembly used for the child: option assignments retain precedence over explicit and inherited selectors, and inherited bytes are not rewritten. Only an absent selector allows the prior fallback.

Missing, unreadable or invalid-UTF8 selected files deny automatic publication without repair. A present empty file selector also denies automatic publication, even if a particular child might interpret it as its default. Manually invoked commands retain their environment and behavior. No parser, public API, ordinary cache, provider, dependency or release-workflow change is included.

## User Impact

- Backups do not infer an iMessage source database when the archive path is absent.
- Missing and stale archives are reported accurately, including legacy data `updated_at`.
- Manual and scheduled mutations do not overlap for the same crawler. Scheduled publication retries do not repeat successful sync; explicit manual sync still performs the requested work.
- Settings sync can publish with unchanged native values and reject changed consent, destination or malformed main config. Explicit standalone Publish is unaffected by this between-phase check.
- Automatic publication checks the selected local native file, including inherited selectors and pending publication-only retries. Empty selectors cannot silently authorize against an unrelated default file.

## Evidence

- Revision `0f43b238` passed [hosted macOS validation](https://github.com/openclaw/crawlbar/actions/runs/34302686907): build, unfiltered full selftest, development CLI, ad-hoc packaging and packaged icon/helper checks. The actual PR merge checkout has the same tree as this source revision. No local Swift execution is claimed.
- The full selftest includes seven original safety entrypoints, 16 supplemental configuration scenarios, retained real-child native marker cases and twelve selector groups. Attribution is through exact-source unconditional registration and the successful full selftest, not a printed per-case transcript.
- Selector coverage includes inherited selection, selected-file changes, failed-publication retries, explicit/option precedence, blank assignments, absent/empty selectors, literal whitespace/relative/tilde paths and frozen inputs. Empty-selector denial is asserted independently of a successful presence-aware probe.
- The relative-path fixture requires directory type and lossless device/inode identity, proves the entered directory is the owned fixture and not runner HOME, and retains raw cwd stability/restoration, literal selectors and child/marker/byte assertions.
- Earlier revision `095c0b16` [built but failed selftest](https://github.com/openclaw/crawlbar/actions/runs/34301834850) at the fixture's cwd setup comparison; its CLI/package/helper steps were skipped. The failed conjunction did not identify its operands. The corrected fixture's success does not establish the earlier failure's exact cause or a production selector defect.
- Earlier revision `a1020b69` also passed [its own hosted macOS validation](https://github.com/openclaw/crawlbar/actions/runs/34298392836). Historical failures, skips and neutral results remain evidence for their respective revisions, not successes retroactively reassigned to them.
- Fixtures use temporary files and fixed marker-writing local children, not real provider uploads, native libraries, TCC or Keychain data. The 16 main-config cases remain supplemental coordinator tests, not real-child consent proof.
- The scheduled Menu main-config cache/predicate remains unchanged. Same-cwd execution, child adherence to the transported selector, and no post-check file race remain explicit limits; arbitrary child parsing, argv overrides and concurrent external edits are not universally covered.
- CI packaging is ad-hoc signed, not Developer ID/notarized release proof. Packaged UI interaction, real native permissions and the exact minimum Swift compiler remain unproved. The repository has no established artifact-publisher workflow; source landing and artifact release are separate.
