### PR TITLE
fix: honor changed consent before scheduled publication

### DIFF
--- a/Sources/CrawlBar/Menu/MenuModel.swift
+++ b/Sources/CrawlBar/Menu/MenuModel.swift
@@ -177,7 +177,7 @@ final class CrawlBarMenuModel: NSObject {
                             action: config.preferredRefreshAction ?? "refresh",
                             scheduledInterval: (config.refreshFrequency ?? refreshFrequency).seconds,
                             allowShare: {
-                                (try? registry.loadConfig().apps.first { $0.id == installation.id }) == config
+                                registry.matchesPersistedRawAppConfig(config)
                                     && nativePublicationGuard()
                             },
                             execute: { action in

--- a/Sources/CrawlBarCore/Registry.swift
+++ b/Sources/CrawlBarCore/Registry.swift
@@ -126,6 +126,14 @@ public struct CrawlAppRegistry: @unchecked Sendable {
         return copy
     }
 
+    package func matchesPersistedRawAppConfig(_ captured: CrawlBarAppConfig) -> Bool {
+        guard let config = try? self.configStore.loadUncached(),
+              let current = config.apps.first(where: { $0.id == captured.id })
+        else { return false }
+        // The scheduler captures raw config; native values have a separate publication guard.
+        return current == captured
+    }
+
     package func matchesPersistedAppConfig(_ captured: CrawlBarAppConfig, manifest: CrawlAppManifest) -> Bool {
         guard let config = try? self.configStore.loadUncached(),
               let current = config.apps.first(where: { $0.id == captured.id })

--- a/Sources/CrawlBarSelfTest/SelfTest.swift
+++ b/Sources/CrawlBarSelfTest/SelfTest.swift
@@ -10,6 +10,7 @@ enum CrawlBarSelfTest {
         try Self.testActionAttemptCadenceAndShareRetry()
         try Self.testActionExclusionAndConsent()
         try Self.testActionSelectedArgumentsAndChangedConfig()
+        try Self.testScheduledPublicationConsent()
         try Self.testExistingCredentialFixOnFailureLogs()
         if CommandLine.arguments.contains("--native-safety") {
             print("crawlbar synthetic native safety selftest ok")

--- a/Sources/CrawlBarSelfTest/SelfTestNativePublicationGuard.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestNativePublicationGuard.swift
@@ -76,7 +76,7 @@ extension CrawlBarSelfTest {
         let first = try coordinator.run(
             installation: fixture.installation, config: fixture.app, configValues: fixture.values, action: "pull", now: now,
             allowShare: {
-                (try? fixture.registry.loadConfig().apps.first { $0.id == fixture.app.id }) == fixture.app && permit()
+                fixture.registry.matchesPersistedRawAppConfig(fixture.app) && permit()
             })
         { action in
             try fixture.runner.run(
@@ -94,7 +94,7 @@ extension CrawlBarSelfTest {
             installation: fixture.installation, config: fixture.app, configValues: retryValues,
             action: "pull", now: now.addingTimeInterval(900), scheduledInterval: 900,
             allowShare: {
-                (try? fixture.registry.loadConfig().apps.first { $0.id == fixture.app.id }) == fixture.app && retryPermit()
+                fixture.registry.matchesPersistedRawAppConfig(fixture.app) && retryPermit()
             })
         { action in
             try fixture.runner.run(

--- a/Sources/CrawlBarSelfTest/SelfTestScheduledPublicationConsent.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestScheduledPublicationConsent.swift
@@ -1,0 +1,208 @@
+import CrawlBarCore
+import Foundation
+
+extension CrawlBarSelfTest {
+    static func testScheduledPublicationConsent() throws {
+        for retry in [false, true] {
+            for change in ScheduledConsentChange.allCases {
+                let fixture = try ScheduledConsentFixture(change: change, failFirstPublication: retry)
+                defer { try? FileManager.default.removeItem(at: fixture.directory) }
+                let coordinator = CrawlActionCoordinator()
+                let now = Date(timeIntervalSince1970: 1_700_000_100)
+                var successfulSync: Date?
+                if retry {
+                    let first = try fixture.run(coordinator, now: now)
+                    try Self.expect(
+                        first.results.map(\.action) == ["pull", "share"]
+                            && first.results.map(\.exitCode) == [0, 7] && first.failure != nil,
+                        "scheduled retry starts with a real failed publisher after successful sync")
+                    successfulSync = coordinator.lastSuccessfulSync(fixture.app.id)
+                    try Self.expect(successfulSync == first.results.first?.finishedAt, "failed publication retains successful sync time")
+                    try fixture.changeMainConfig()
+                }
+                let outcome = try fixture.run(coordinator, now: retry ? now.addingTimeInterval(900) : now) {
+                    if !retry { try fixture.changeMainConfig() }
+                }
+                let publish = change == .unchanged
+                let expectedActions = retry ? (publish ? ["share"] : []) : (publish ? ["pull", "share"] : ["pull"])
+                try Self.expect(outcome.failure == nil && outcome.results.map(\.action) == expectedActions, "scheduled consent phases \(change), retry \(retry)")
+                try Self.expect(try fixture.marker("sync") == "sync\n", "scheduled consent never repeats successful sync")
+                let expectedPublish = (retry ? "publish\n" : "") + (publish ? "publish\n" : "")
+                try Self.expect(try fixture.marker("publish") == expectedPublish, "real publication child obeys consent \(change), retry \(retry)")
+                if !retry && !publish {
+                    try Self.expect(
+                        !FileManager.default.fileExists(atPath: fixture.directory.appendingPathComponent("publish.marker").path),
+                        "denied initial publication creates no child marker")
+                }
+                let expectedSync = retry ? successfulSync : outcome.results.first?.finishedAt
+                try Self.expect(coordinator.lastSuccessfulSync(fixture.app.id) == expectedSync, "consent check preserves successful sync")
+                try fixture.expectExternalConfigPreserved()
+            }
+        }
+        print("crawlbar scheduled publication consent selftest ok (10 cases)")
+    }
+}
+
+private enum ScheduledConsentChange: CaseIterable {
+    case unchanged
+    case shareDisabled
+    case afterRefreshDisabled
+    case malformed
+    case missing
+}
+
+private struct ScheduledConsentFixture {
+    let directory: URL
+    let mainURL: URL
+    let nativeURL: URL
+    let app: CrawlBarAppConfig
+    let registry: CrawlAppRegistry
+    let installation: CrawlAppInstallation
+    let runner: CrawlCommandRunner
+    let values: [String: String]
+    let initialMain: Data
+    let nextMain: Data
+    let initialNative: Data
+    let change: ScheduledConsentChange
+    let modificationDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    init(change: ScheduledConsentChange, failFirstPublication: Bool) throws {
+        let fm = FileManager.default
+        let directory = fm.temporaryDirectory.appendingPathComponent("crawlbar-scheduled-consent-\(UUID())")
+        try fm.createDirectory(at: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let mainURL = directory.appendingPathComponent("config.json")
+        let nativeURL = directory.appendingPathComponent("native.toml")
+        let scriptURL = directory.appendingPathComponent("child.sh")
+        try Self.script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        var manifest = CrawlBarSelfTest.nativeFixtureManifest(commands: [
+            "pull": [scriptURL.path, "sync"], "share": [scriptURL.path, "publish"],
+        ], binary: "/bin/sh")
+        manifest.paths = .init(defaultConfig: nativeURL.path, configEnv: "SCHEDULED_NATIVE_CONFIG")
+        manifest.configOptions = [
+            .init(id: "destination", label: "Destination", configKey: "share.repo_path"),
+        ]
+        let app = CrawlBarAppConfig(
+            id: manifest.id, binaryPath: "/bin/sh", configPath: nativeURL.path,
+            preferredRefreshAction: "pull", autoRefreshEnabled: true,
+            shareEnabled: true, shareAfterRefresh: true, preferredShareAction: "share")
+        let config = CrawlBarConfig(manifestDirectories: [directory.appendingPathComponent("apps").path], apps: [app])
+        let initialMain = try CrawlCoding.makeJSONEncoder().encode(config)
+        try initialMain.write(to: mainURL)
+        let initialNative = Data("[share]\nrepo_path = \"A\"\n".utf8)
+        try initialNative.write(to: nativeURL)
+        let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
+        for url in [mainURL, nativeURL] {
+            try fm.setAttributes([.modificationDate: fixedDate, .posixPermissions: 0o600], ofItemAtPath: url.path)
+            let date = try fm.attributesOfItem(atPath: url.path)[.modificationDate] as? Date
+            try CrawlBarSelfTest.expect(date == fixedDate, "scheduled fixture establishes exact mtime before cache prime")
+        }
+        let store = CrawlBarConfigStore(fileURL: mainURL, cache: CrawlBarConfigCache())
+        let registry = CrawlAppRegistry(
+            configStore: store, catalog: CrawlManifestCatalog(scanCache: CrawlManifestScanCache()),
+            nativeConfigStore: CrawlNativeConfigStore(cache: CrawlNativeConfigCache()))
+        let captured = try registry.loadConfig().apps.first { $0.id == app.id }
+        try CrawlBarSelfTest.expect(captured == app && app.configValues.isEmpty, "scheduler captures raw main config")
+        let installation = CrawlAppInstallation(
+            manifest: manifest, binaryPath: "/bin/sh", configPathOverride: nativeURL.path,
+            configValues: registry.appConfigWithNativeValues(app, manifest: manifest, includeSecrets: false).configValues)
+        let values = registry.executionConfigValues(for: installation)
+        try CrawlBarSelfTest.expect(values == ["destination": "A"], "native-only values differ from raw scheduler config")
+        let nextMain: Data
+        switch change {
+        case .unchanged, .missing:
+            nextMain = initialMain
+        case .malformed:
+            nextMain = Data("{".utf8)
+        case .shareDisabled, .afterRefreshDisabled:
+            var next = config
+            if change == .shareDisabled {
+                next.apps[0].shareEnabled = false
+            } else {
+                next.apps[0].shareAfterRefresh = false
+            }
+            nextMain = try CrawlCoding.makeJSONEncoder().encode(next)
+        }
+        self.directory = directory
+        self.mainURL = mainURL
+        self.nativeURL = nativeURL
+        self.app = app
+        self.registry = registry
+        self.installation = installation
+        self.values = values
+        self.runner = CrawlCommandRunner(environment: [
+            "HOME": directory.path, "TMPDIR": directory.path, "PATH": "/usr/bin:/bin",
+            "XDG_CONFIG_HOME": directory.path, "XDG_CACHE_HOME": directory.path, "XDG_DATA_HOME": directory.path,
+            "FAIL_FIRST_PUBLICATION": failFirstPublication ? "1" : "0",
+        ])
+        self.initialMain = initialMain
+        self.nextMain = nextMain
+        self.initialNative = initialNative
+        self.change = change
+    }
+
+    func run(_ coordinator: CrawlActionCoordinator, now: Date, afterSync: () throws -> Void = {}) throws -> CrawlActionOutcome {
+        let nativeGuard = self.registry.nativePublicationGuard(
+            for: self.installation, configValues: self.values, runner: self.runner)
+        return try coordinator.run(
+            installation: self.installation, config: self.app, configValues: self.values,
+            action: "pull", now: now, scheduledInterval: 900,
+            allowShare: { self.registry.matchesPersistedRawAppConfig(self.app) && nativeGuard() })
+        { action in
+            let result = try self.runner.run(
+                installation: self.installation, configValues: self.values, action: action, timeoutSeconds: 5)
+            if action == "pull" { try afterSync() }
+            return result
+        }
+    }
+
+    func changeMainConfig() throws {
+        if self.change == .missing {
+            try FileManager.default.removeItem(at: self.mainURL)
+            return
+        }
+        // External writes bypass save(), leaving the already-primed cache stale.
+        try self.nextMain.write(to: self.mainURL)
+        try FileManager.default.setAttributes([.modificationDate: self.modificationDate], ofItemAtPath: self.mainURL.path)
+        let date = try FileManager.default.attributesOfItem(atPath: self.mainURL.path)[.modificationDate] as? Date
+        try CrawlBarSelfTest.expect(date == self.modificationDate, "external main overwrite restores the exact primed mtime")
+        if self.change != .unchanged {
+            try CrawlBarSelfTest.expect(self.nextMain != self.initialMain, "same-mtime overwrite actually changes config bytes")
+        }
+        try CrawlBarSelfTest.expect(
+            try self.registry.loadConfig().apps.first { $0.id == self.app.id } == self.app,
+            "cached scheduler read still returns old consent after the same-mtime write")
+    }
+
+    func expectExternalConfigPreserved() throws {
+        if self.change == .missing {
+            try CrawlBarSelfTest.expect(!FileManager.default.fileExists(atPath: self.mainURL.path), "missing main config is not recreated")
+        } else {
+            try CrawlBarSelfTest.expect(try Data(contentsOf: self.mainURL) == self.nextMain, "guard preserves external main config bytes")
+            let date = try FileManager.default.attributesOfItem(atPath: self.mainURL.path)[.modificationDate] as? Date
+            try CrawlBarSelfTest.expect(date == self.modificationDate, "guard preserves external main mtime")
+        }
+        try CrawlBarSelfTest.expect(try Data(contentsOf: self.nativeURL) == self.initialNative, "main consent check leaves native config unchanged")
+        let nativeDate = try FileManager.default.attributesOfItem(atPath: self.nativeURL.path)[.modificationDate] as? Date
+        try CrawlBarSelfTest.expect(nativeDate == self.modificationDate, "main consent check leaves native mtime unchanged")
+    }
+
+    func marker(_ name: String) throws -> String {
+        let url = self.directory.appendingPathComponent("\(name).marker")
+        guard FileManager.default.fileExists(atPath: url.path) else { return "" }
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private static let script = #"""
+    set -eu
+    case "$1" in
+      sync) printf 'sync\n' >> "$HOME/sync.marker" ;;
+      publish)
+        already=0
+        if [ -f "$HOME/publish.marker" ]; then already=1; fi
+        printf 'publish\n' >> "$HOME/publish.marker"
+        if [ "$FAIL_FIRST_PUBLICATION" = 1 ] && [ "$already" = 0 ]; then exit 7; fi
+        ;;
+      *) exit 64 ;;
+    esac
+    """#
+}

--- a/docs/control-protocol.md
+++ b/docs/control-protocol.md
@@ -95,6 +95,12 @@ CrawlBar also accepts its legacy array-only form and never shell-expands either.
 - `query` should run a local read-only search or SQL-ish query. CrawlBar passes
   user query text as additional argv after the manifest command array.
 - `publish`, `update`, and exporter actions are optional and should return JSON when possible.
+- Automatic publication after a refresh, including a retry after publication
+  fails, re-reads the main configuration from disk immediately before starting
+  the publication command. Revoked sharing consent, changed crawler settings,
+  or a missing or malformed main configuration stops publication without
+  recreating the configuration file. Unchanged settings still permit publication,
+  including values supplied only by the crawler's native configuration.
 - `remote-status` and `remote-archives` should be read-only wrappers around
   Cloudflare or equivalent remote archive status/listing commands.
 - `cloud-publish` may upload rows and compressed SQLite bundle parts to a


### PR DESCRIPTION
## What Problem This Solves

Fixes scheduled publication continuing after an external configuration edit revokes sharing consent but preserves the file modification time. The same stale-consent check affected retries after a failed publication.

## Why This Change Was Made

Compare the scheduler's captured raw configuration with an uncached, noncreating disk read immediately before publication. Keep the separate native-configuration guard and successful-sync retry behavior. Document the automatic-publication contract.

This carries Vincent Koc's implementation and regression coverage from #30 with his co-author credit preserved. GitHub reported maintainer edits disabled on that PR, so this replacement keeps the original branch untouched. Its release-note entry is prepared in a separate notes PR to avoid conflicts between sibling branches.

## User Impact

Either revoked sharing flag, changed crawler settings, or missing/malformed configuration stops automatic publication. Missing configuration is not recreated by the check. Unchanged native-only settings still allow publishing, and an allowed retry does not repeat a successful sync.

## Evidence

- Reproduced failure using the old scheduled check: the process-boundary regression fails at `scheduled consent phases shareDisabled, retry false`.
- `swift build` and the full `swift run crawlbar-selftest` pass, including 10 initial-publication/retry cases with real child-process markers.
- Source and packaged brand-icon checks pass. Built and packaged CLI smoke covers `apps --json`, `metadata --json`, and `config validate` with an isolated synthetic home.
- Packaged app and helper signed with the OpenClaw Foundation Developer ID; strict signature verification passes.
- Local and committed-branch Codex autoreview: no actionable P0–P2 findings.
- Signed packaged app launched with an isolated synthetic home. Peekaboo opened Settings and activated Refresh All. At the app scheduler tick, both synthetic crawlers synced; only the unchanged-consent crawler published. The other revoked consent during sync while preserving the exact config timestamp and created no publication marker.
- macOS CI passed on the exact PR head: https://github.com/openclaw/crawlbar/actions/runs/34662736447 . Final check results are recorded in the proof comment.

Related: #30.
