### PR TITLE
docs: prepare 0.4.2 reliability release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,19 @@
 
 ## v0.4.2 - Unreleased
 
+**Highlights:** More reliable publishing consent checks, safer archive backups, and bounded waits for stalled crawler commands.
+
 ### Fixes
 
-- Map iMessage archive paths without exposing the Messages source database to backup selection.
-- Keep status check timestamps separate from import/sync freshness and recognize missing external archives as requiring setup.
-- Preserve recursive configuration substitution while bounding cycles and expansion.
-- Coordinate manual and scheduled mutations per crawler, respect retry intervals after failed attempts, and retry failed publication without repeating successful sync.
-- Apply both share consent settings to manual sync publication and discard superseded action status updates.
-- Allow Settings sync to publish with unchanged native configuration, while stopping automatic publication when consent or nonsecret configuration changes or the main config is missing or invalid.
-- Re-read the main config before automatic publication so external consent, destination or malformed-file changes cannot be hidden by a cached modification time.
-- Stop automatic publication and scheduled publication retries when native config-only values change or their selected local config becomes unreadable, even if saved Settings values mask the change.
-- Check the native configuration selected by the command environment before automatic publication; refuse an empty configuration-file selector without changing manually invoked commands.
-- Restore legacy data `updated_at` as a freshness fallback without treating status-generation time as fresh data.
-- Keep crawler credentials out of UI/CLI installation state and redact echoed credentials before command output or action-log persistence. Thanks @vincentkoc.
-- Bound crawler-command and Homebrew-install timeout teardown so actions return when process termination fails. Thanks @SebTardif.
-- Bound SQLite backup process waits to 600 seconds so wedged backups return a timeout instead of hanging Settings or the CLI. Thanks @SebTardif.
+- Honor revoked sharing consent before scheduled publication and retries, even when external config edits preserve the file timestamp; stop on missing or malformed config without recreating it. Thanks @vincentkoc.
+- Recheck both sharing consent settings and main/native configuration before automatic publication, including changes hidden by saved Settings values; unchanged native-only settings still permit publishing. Thanks @vincentkoc.
+- Validate the native configuration selected by the command environment before automatic publication, refusing empty selectors or unreadable config while preserving manually invoked commands. Thanks @vincentkoc.
+- Coordinate manual and scheduled mutations per crawler, respect retry intervals after failures, retry publication without repeating successful sync, and discard superseded status updates. Thanks @vincentkoc.
+- Keep crawler credentials out of UI/CLI installation state and redact echoed credentials before displaying command output or saving action logs. Thanks @vincentkoc.
+- Keep iMessage backups limited to archive databases, excluding the Messages source database. Thanks @vincentkoc.
+- Bound crawler-command and Homebrew-install timeout teardown when process termination fails, and limit SQLite backup waits to 600 seconds so stalled actions return. Thanks @SebTardif.
+- Keep status-check timestamps separate from import/sync freshness, retain legacy data `updated_at` as a fallback, and recognize missing external archives as requiring setup. Thanks @vincentkoc.
+- Preserve recursive configuration substitution while bounding cycles and expansion. Thanks @vincentkoc.
 
 ## v0.4.1 - 2026-07-09
 


### PR DESCRIPTION
## What Problem This Solves

The pending 0.4.2 notes have accumulated overlapping implementation details since v0.4.1. Prepare one ordered, user-facing release summary with contributor credit and the scheduled-consent fix from #31.

## Why This Change Was Made

Consolidate the Unreleased section around publishing consent, action reliability, credential redaction, archive-only backups, and freshness. This is the sole changelog PR for this pass and branches directly from main; merge it after #31. Released sections and version metadata stay unchanged.

## User Impact

Clearer release notes for a recommended patch release, 0.4.2. No application behavior changes in this PR.

## Evidence

- Cross-checked all commits since v0.4.1, the existing Unreleased entries, and #31; preserved released sections verbatim.
- Dependency audit found no external Swift packages and no stale Actions versions: checkout uses the current v7 major, and create-github-app-token is pinned to v3.2.0, the latest release.
- Whitespace validation and both local and committed-branch Codex autoreview pass with no actionable P0–P2 findings. Exact-head CI is recorded in the proof comment.
- Release preparation only. No tag or publication. Official release still requires the merged-head CI check, universal signed and notarized packaging, artifact verification, GitHub Release, and Homebrew update.
