### PR TITLE
refactor: share bounded crawler process execution

### DIFF
--- a/Sources/CrawlBarCore/CommandRunner.swift
+++ b/Sources/CrawlBarCore/CommandRunner.swift
@@ -66,8 +66,6 @@ public struct CrawlCommandRunner: @unchecked Sendable {
         let executableName: String
         if executionKind == .ssh {
             executableName = "ssh"
-        } else if effectiveBinaryName != installation.manifest.binary.name {
-            executableName = installation.binaryPath ?? effectiveBinaryName
         } else {
             executableName = installation.binaryPath ?? effectiveBinaryName
         }

--- a/Sources/CrawlBarCore/DatabaseBackup.swift
+++ b/Sources/CrawlBarCore/DatabaseBackup.swift
@@ -105,15 +105,11 @@ public enum CrawlDatabaseBackupStore {
             if FileManager.default.fileExists(atPath: destination.path) {
                 try FileManager.default.removeItem(at: destination)
             }
-            if entry.resource.kind == .sqlite || entry.resource.kind == .cache {
-                try Self.backupSQLite(
-                    source: entry.source,
-                    destination: destination,
-                    resolver: resolver,
-                    timeoutSeconds: sqliteProcessTimeout)
-            } else {
-                try FileManager.default.copyItem(at: entry.source, to: destination)
-            }
+            try Self.backupSQLite(
+                source: entry.source,
+                destination: destination,
+                resolver: resolver,
+                timeoutSeconds: sqliteProcessTimeout)
             copied.append(destination.path)
         }
 

--- a/Sources/CrawlBarCore/Installer.swift
+++ b/Sources/CrawlBarCore/Installer.swift
@@ -60,49 +60,18 @@ public struct CrawlInstaller: @unchecked Sendable {
         timeoutSeconds: TimeInterval)
         throws -> CrawlCommandResult
     {
-        let startedAt = Date()
-        let tempDirectory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("crawlbar-install-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tempDirectory) }
-
-        let stdoutURL = tempDirectory.appendingPathComponent("stdout.log")
-        let stderrURL = tempDirectory.appendingPathComponent("stderr.log")
-        FileManager.default.createFile(atPath: stdoutURL.path, contents: nil)
-        FileManager.default.createFile(atPath: stderrURL.path, contents: nil)
-
-        let stdoutHandle = try FileHandle(forWritingTo: stdoutURL)
-        let stderrHandle = try FileHandle(forWritingTo: stderrURL)
-        defer {
-            try? stdoutHandle.close()
-            try? stderrHandle.close()
-        }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: executablePath)
-        process.arguments = arguments
-        process.environment = self.environment
-        process.standardOutput = stdoutHandle
-        process.standardError = stderrHandle
-
-        try process.run()
-        if CrawlProcessWait.waitUntilExit(process, timeoutSeconds: timeoutSeconds) == .timedOut {
-            throw CrawlCommandRunnerError.timedOut(appID: appID, action: "install", seconds: Int(timeoutSeconds))
-        }
-
-        try? stdoutHandle.synchronize()
-        try? stderrHandle.synchronize()
-
-        let stdout = try String(contentsOf: stdoutURL, encoding: .utf8)
-        let stderr = try String(contentsOf: stderrURL, encoding: .utf8)
-        let result = CrawlCommandResult(
+        let runner = CrawlCommandRunner(
+            resolver: self.resolver,
+            redactor: self.redactor,
+            environment: self.environment)
+        let result = try runner.runProcess(
             appID: appID,
             action: "install",
-            exitCode: process.terminationStatus,
-            stdout: self.redactor.redact(stdout),
-            stderr: self.redactor.redact(stderr),
-            startedAt: startedAt,
-            finishedAt: Date())
+            executablePath: executablePath,
+            arguments: arguments,
+            environment: self.environment,
+            maskedValues: [],
+            timeoutSeconds: timeoutSeconds)
         if result.exitCode != 0 {
             throw CrawlInstallerError.failed(result.stderr.nilIfBlank ?? result.stdout.nilIfBlank ?? "Install failed with exit \(result.exitCode)")
         }

--- a/Sources/CrawlBarCore/StatusService.swift
+++ b/Sources/CrawlBarCore/StatusService.swift
@@ -28,22 +28,20 @@ public struct CrawlStatusService: @unchecked Sendable {
         if let status = self.immediateStatus(for: installation) {
             return status
         }
-        if installation.id == BuiltInCrawlApps.gogcliID {
-            return self.gogcliStatus(
-                for: installation,
-                configValues: configValues,
-                timeoutSeconds: timeoutSeconds)
-        }
         do {
-            let result = try self.runner.run(
-                installation: installation,
+            let status = try self.commandStatus(
+                for: installation,
                 configValues: configValues,
                 action: "status",
                 timeoutSeconds: timeoutSeconds)
-            return self.mapper.status(
-                from: result,
-                manifest: installation.manifest,
-                staleAfterSeconds: installation.staleAfterSeconds)
+            guard installation.id == BuiltInCrawlApps.gogcliID, status.state != .current else {
+                return status
+            }
+            return try self.commandStatus(
+                for: installation,
+                configValues: configValues,
+                action: "doctor",
+                timeoutSeconds: timeoutSeconds)
         } catch CrawlCommandRunnerError.timedOut {
             return CrawlAppStatus(
                 appID: installation.id,
@@ -69,43 +67,21 @@ public struct CrawlStatusService: @unchecked Sendable {
         return GitcrawlStatusSnapshot.status(for: installation)
     }
 
-    private func gogcliStatus(
+    private func commandStatus(
         for installation: CrawlAppInstallation,
         configValues: [String: String],
+        action: String,
         timeoutSeconds: TimeInterval)
-        -> CrawlAppStatus
+        throws -> CrawlAppStatus
     {
-        do {
-            let statusResult = try self.runner.run(
-                installation: installation,
-                configValues: configValues,
-                action: "status",
-                timeoutSeconds: timeoutSeconds)
-            let status = self.mapper.status(
-                from: statusResult,
-                manifest: installation.manifest,
-                staleAfterSeconds: installation.staleAfterSeconds)
-            if status.state == .current {
-                return status
-            }
-            let doctorResult = try self.runner.run(
-                installation: installation,
-                configValues: configValues,
-                action: "doctor",
-                timeoutSeconds: timeoutSeconds)
-            return self.mapper.status(
-                from: doctorResult,
-                manifest: installation.manifest,
-                staleAfterSeconds: installation.staleAfterSeconds)
-        } catch CrawlCommandRunnerError.timedOut {
-            return CrawlAppStatus(
-                appID: installation.id,
-                state: .unknown,
-                summary: "Status check is slow; run Doctor for a full check")
-        } catch CrawlCommandRunnerError.missingRequiredConfig {
-            return CrawlAppStatus(appID: installation.id, state: .needsConfig, summary: "Remote settings are incomplete")
-        } catch {
-            return CrawlAppStatus(appID: installation.id, state: .error, summary: error.localizedDescription, errors: [error.localizedDescription])
-        }
+        let result = try self.runner.run(
+            installation: installation,
+            configValues: configValues,
+            action: action,
+            timeoutSeconds: timeoutSeconds)
+        return self.mapper.status(
+            from: result,
+            manifest: installation.manifest,
+            staleAfterSeconds: installation.staleAfterSeconds)
     }
 }

--- a/Sources/CrawlBarSelfTest/SelfTestStorageAndRedaction.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestStorageAndRedaction.swift
@@ -207,8 +207,8 @@ extension CrawlBarSelfTest {
         for name in ["CrawlCommandRunnerProcess.swift", "Installer.swift"] {
             let text = try String(contentsOf: core.appendingPathComponent(name), encoding: .utf8)
             try Self.expect(
-                text.contains("CrawlProcessWait.waitUntilExit"),
-                "\(name) waits through CrawlProcessWait")
+                text.contains(name == "Installer.swift" ? "runner.runProcess(" : "CrawlProcessWait.waitUntilExit"),
+                "\(name) uses the shared bounded process runner")
             try Self.expect(
                 !text.contains("process.waitUntilExit()"),
                 "\(name) does not call unbounded Process.waitUntilExit")


### PR DESCRIPTION
## What Problem This Solves

Crawler commands and Homebrew installation had separate copies of subprocess capture, timeout teardown, and redaction. Google status also duplicated the normal status/error path, making reliability fixes easy to apply inconsistently.

## Why This Change Was Made

Installation now uses the existing bounded command runner, and Google uses the same status execution/error mapping with its existing doctor fallback. Remove redundant executable selection and an unreachable plain-copy backup branch: backup resources are already filtered to SQLite/cache entries. Public APIs, command arguments, timeout errors, and supported backup kinds stay unchanged.

## User Impact

No intended behavior change. Future process and status fixes have one owner.

## Evidence

- `swift build` passed (Swift 6.4, macOS); `swift run --skip-build crawlbar-selftest` passed, including real child-process timeout, installer timeout, SQLite backup and consent checks. The source-level timeout assertion follows installer delegation; all executable timeout assertions remain.
- Built `crawlbarctl`, using a synthetic crawler and isolated `CFFIXED_USER_HOME`: `config validate` returned `ok`; `metadata --app fixturecrawl --json` preserved commands; `status --app fixturecrawl --json` returned `current`, `Synthetic archive ready`, 42 messages; `doctor --app fixturecrawl --json` returned exit 0 and `synthetic action complete`.
- Isolated Codex autoreview at P0–P2: scoped-clean. An initial backup finding was disproved by supplying the unchanged resource filter; the complete-source review confirms only SQLite/cache resources reach backup execution.
