### PR TITLE
refactor: tighten concurrency checks and scope cache locks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,29 +14,17 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "CrawlBarCore",
-            swiftSettings: [
-                .enableUpcomingFeature("StrictConcurrency"),
-            ]),
+            name: "CrawlBarCore"),
         .executableTarget(
             name: "CrawlBar",
             dependencies: ["CrawlBarCore"],
             resources: [
                 .process("Resources"),
-            ],
-            swiftSettings: [
-                .enableUpcomingFeature("StrictConcurrency"),
             ]),
         .executableTarget(
             name: "CrawlBarCLI",
-            dependencies: ["CrawlBarCore"],
-            swiftSettings: [
-                .enableUpcomingFeature("StrictConcurrency"),
-            ]),
+            dependencies: ["CrawlBarCore"]),
         .executableTarget(
             name: "CrawlBarSelfTest",
-            dependencies: ["CrawlBarCore"],
-            swiftSettings: [
-                .enableUpcomingFeature("StrictConcurrency"),
-            ]),
+            dependencies: ["CrawlBarCore"]),
     ])

--- a/Sources/CrawlBarCore/Config/CrawlBarConfigCache.swift
+++ b/Sources/CrawlBarCore/Config/CrawlBarConfigCache.swift
@@ -14,17 +14,17 @@ public final class CrawlBarConfigCache: @unchecked Sendable {
     public init() {}
 
     func config(path: String, modificationDate: Date?) -> CrawlBarConfig? {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        guard let entry = self.entries[path], entry.modificationDate == modificationDate else {
-            return nil
+        self.lock.withLock {
+            guard let entry = self.entries[path], entry.modificationDate == modificationDate else {
+                return nil
+            }
+            return entry.config
         }
-        return entry.config
     }
 
     func set(_ config: CrawlBarConfig, path: String, modificationDate: Date?) {
-        self.lock.lock()
-        self.entries[path] = Entry(modificationDate: modificationDate, config: config)
-        self.lock.unlock()
+        self.lock.withLock {
+            self.entries[path] = Entry(modificationDate: modificationDate, config: config)
+        }
     }
 }

--- a/Sources/CrawlBarCore/CrawlActionCoordinator.swift
+++ b/Sources/CrawlBarCore/CrawlActionCoordinator.swift
@@ -92,7 +92,7 @@ package final class CrawlActionCoordinator: @unchecked Sendable {
             }
             return (generation, resume)
         }
-        defer { self.lock.withLock { self.running.remove(appID) } }
+        defer { _ = self.lock.withLock { self.running.remove(appID) } }
 
         var actions = resumePublish ? [shareAction] : [action]
         if share && !resumePublish && shareAction != action { actions.append(shareAction) }

--- a/Sources/CrawlBarCore/CrawlExecutableResolver.swift
+++ b/Sources/CrawlBarCore/CrawlExecutableResolver.swift
@@ -12,27 +12,17 @@ public final class CrawlExecutableResolver: @unchecked Sendable {
     }
 
     public func resolve(_ requestedPathOrName: String) -> String? {
-        self.lock.lock()
-        if let cached = self.resolvedExecutables[requestedPathOrName] {
-            self.lock.unlock()
+        if let cached = self.lock.withLock({ self.resolvedExecutables[requestedPathOrName] }) {
             if self.isExecutable(cached) {
                 return cached
             }
-            self.lock.lock()
-            self.resolvedExecutables.removeValue(forKey: requestedPathOrName)
-            self.lock.unlock()
-        } else {
-            self.lock.unlock()
+            _ = self.lock.withLock { self.resolvedExecutables.removeValue(forKey: requestedPathOrName) }
         }
 
         let resolved = self.resolveUncached(requestedPathOrName)
-        self.lock.lock()
-        if let resolved {
+        self.lock.withLock {
             self.resolvedExecutables[requestedPathOrName] = resolved
-        } else {
-            self.resolvedExecutables.removeValue(forKey: requestedPathOrName)
         }
-        self.lock.unlock()
         return resolved
     }
 

--- a/Sources/CrawlBarCore/Installer.swift
+++ b/Sources/CrawlBarCore/Installer.swift
@@ -20,7 +20,7 @@ public enum CrawlInstallerError: LocalizedError, Sendable {
     }
 }
 
-public struct CrawlInstaller: @unchecked Sendable {
+public struct CrawlInstaller: Sendable {
     private let resolver: CrawlExecutableResolver
     private let redactor: CrawlCommandRedactor
     private let environment: [String: String]

--- a/Sources/CrawlBarCore/ManifestCatalog.swift
+++ b/Sources/CrawlBarCore/ManifestCatalog.swift
@@ -99,17 +99,14 @@ public final class CrawlManifestScanCache: @unchecked Sendable {
     {
         let key = directories.map { PathExpander.expandHome($0) }.joined(separator: "\u{0}")
         let now = Date()
-        self.lock.lock()
-        if let entry = self.entries[key], now.timeIntervalSince(entry.loadedAt) < self.timeToLive {
-            self.lock.unlock()
+        if let entry = self.lock.withLock({ self.entries[key] }), now.timeIntervalSince(entry.loadedAt) < self.timeToLive {
             return (entry.manifests, entry.diagnostics)
         }
-        self.lock.unlock()
 
         let result = load()
-        self.lock.lock()
-        self.entries[key] = Entry(loadedAt: now, manifests: result.manifests, diagnostics: result.diagnostics)
-        self.lock.unlock()
+        self.lock.withLock {
+            self.entries[key] = Entry(loadedAt: now, manifests: result.manifests, diagnostics: result.diagnostics)
+        }
         return result
     }
 }

--- a/Sources/CrawlBarCore/NativeConfig.swift
+++ b/Sources/CrawlBarCore/NativeConfig.swift
@@ -279,27 +279,27 @@ public final class CrawlNativeConfigCache: @unchecked Sendable {
 
     func values(path: String, appID: CrawlAppID, manifestSignature: String, modificationDate: Date?) -> [String: String]? {
         let key = self.key(path: path, appID: appID, manifestSignature: manifestSignature)
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        guard let entry = self.entries[key], entry.modificationDate == modificationDate else {
-            return nil
+        return self.lock.withLock {
+            guard let entry = self.entries[key], entry.modificationDate == modificationDate else {
+                return nil
+            }
+            return entry.values
         }
-        return entry.values
     }
 
     func set(_ values: [String: String], path: String, appID: CrawlAppID, manifestSignature: String, modificationDate: Date?) {
         let key = self.key(path: path, appID: appID, manifestSignature: manifestSignature)
-        self.lock.lock()
-        self.entries[key] = Entry(modificationDate: modificationDate, values: values)
-        self.lock.unlock()
+        self.lock.withLock {
+            self.entries[key] = Entry(modificationDate: modificationDate, values: values)
+        }
     }
 
     func remove(path: String, appID: CrawlAppID) {
-        self.lock.lock()
-        self.entries = self.entries.filter { key, _ in
-            !key.hasPrefix("\(appID.rawValue)\u{0}\(path)\u{0}")
+        self.lock.withLock {
+            self.entries = self.entries.filter { key, _ in
+                !key.hasPrefix("\(appID.rawValue)\u{0}\(path)\u{0}")
+            }
         }
-        self.lock.unlock()
     }
 
     private func key(path: String, appID: CrawlAppID, manifestSignature: String) -> String {

--- a/Sources/CrawlBarCore/Registry.swift
+++ b/Sources/CrawlBarCore/Registry.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct CrawlAppRegistry: @unchecked Sendable {
+public struct CrawlAppRegistry: Sendable {
     private let configStore: CrawlBarConfigStore
     private let catalog: CrawlManifestCatalog
     private let resolver: CrawlExecutableResolver

--- a/Sources/CrawlBarCore/SecretStore.swift
+++ b/Sources/CrawlBarCore/SecretStore.swift
@@ -18,7 +18,7 @@ public enum CrawlSecretStoreError: LocalizedError, Sendable {
     }
 }
 
-public struct CrawlSecretStore: @unchecked Sendable {
+public struct CrawlSecretStore: Sendable {
     private let service: String
 
     public init(service: String = "com.vincentkoc.CrawlBar") {

--- a/Sources/CrawlBarCore/StatusService.swift
+++ b/Sources/CrawlBarCore/StatusService.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct CrawlStatusService: @unchecked Sendable {
+public struct CrawlStatusService: Sendable {
     private let runner: CrawlCommandRunner
     private let mapper: CrawlStatusMapper
 


### PR DESCRIPTION
## What Problem This Solves

Unchecked concurrency declarations and manual lock/unlock pairs obscure which CrawlBar types the compiler can actually verify.

## Why This Change Was Made

Use checked `Sendable` for the registry, status service, installer, and secret-store value wrappers. Keep the original unchecked conformance for Foundation `FileManager` owners and lock-protected reference caches. Scope cache access with `NSLock.withLock`, remove Swift 6's redundant upcoming-feature flags, and explicitly discard the coordinator's lock result.

## User Impact

No runtime or API change; the Swift 6.1/macOS 14 floor is unchanged. More concurrency assumptions are checked at compile time, and cache locking has fewer exit paths.

## Evidence

- `swift build` passed without warnings; `swift run --skip-build crawlbar-selftest` passed, including config-cache and publication-consent checks.
- Built CLI, synthetic isolated home: `status --app fixturecrawl --json` returned `current`, `Synthetic archive ready`, and 42 messages.
- Isolated Codex autoreview: scoped-clean at P0–P2.
