### PR TITLE
refactor: remove obsolete menu and command helpers

### DIFF
--- a/Sources/CrawlBar/Branding/CrawlBarIconFactory.swift
+++ b/Sources/CrawlBar/Branding/CrawlBarIconFactory.swift
@@ -5,7 +5,6 @@ import CrawlBarCore
 enum CrawlBarIconFactory {
     private static var imageCache: [String: NSImage] = [:]
     private static var menuBarImageCache: [String: NSImage] = [:]
-    private static var statusDotImageCache: [String: NSImage] = [:]
 
     static func image(for appID: CrawlAppID, manifest: CrawlAppManifest?, size: CGFloat = 32) -> NSImage {
         let cacheKey = [
@@ -83,26 +82,6 @@ enum CrawlBarIconFactory {
         return image
     }
 
-    static func statusDotImage(for state: CrawlAppState, size: CGFloat = 12) -> NSImage {
-        let cacheKey = "\(state.rawValue)|\(Self.cacheSizeKey(for: size))"
-        if let cached = Self.statusDotImageCache[cacheKey] {
-            return cached
-        }
-        let image = NSImage(size: NSSize(width: size, height: size))
-        image.lockFocus()
-        let rect = NSRect(x: 2, y: 2, width: size - 4, height: size - 4)
-        let dot = NSBezierPath(ovalIn: rect)
-        Self.statusColor(for: state).setFill()
-        dot.fill()
-        NSColor.separatorColor.withAlphaComponent(0.5).setStroke()
-        dot.lineWidth = 0.75
-        dot.stroke()
-        image.unlockFocus()
-        image.isTemplate = false
-        Self.statusDotImageCache[cacheKey] = image
-        return image
-    }
-
     static func appIconImage() -> NSImage? {
         for bundle in Self.resourceBundleCandidates() {
             if let url = bundle.url(forResource: "AppIcon", withExtension: "png") {
@@ -114,19 +93,6 @@ enum CrawlBarIconFactory {
 
     static func cacheSizeKey(for size: CGFloat) -> Int {
         Int((size * 2).rounded())
-    }
-
-    static func statusColor(for state: CrawlAppState) -> NSColor {
-        switch state {
-        case .current:
-            NSColor.systemGreen
-        case .stale, .syncing, .unknown:
-            NSColor.systemYellow
-        case .needsConfig, .needsAuth, .error:
-            NSColor.systemRed
-        case .disabled:
-            NSColor.systemGray
-        }
     }
 
     static func brandedImage(for appID: CrawlAppID, manifest: CrawlAppManifest?, size: CGFloat) -> NSImage? {

--- a/Sources/CrawlBar/Menu/CrawlBarMenuItemHostingView.swift
+++ b/Sources/CrawlBar/Menu/CrawlBarMenuItemHostingView.swift
@@ -15,10 +15,8 @@ protocol CrawlBarMenuItemHighlighting: AnyObject {
 final class CrawlBarMenuItemHostingView: NSView, CrawlBarMenuItemMeasuring, CrawlBarMenuItemHighlighting {
     private let highlightState: CrawlBarMenuItemHighlightState?
     private let hostingController: NSHostingController<AnyView>
-    private var contentVersion = 0
     private var cachedWidth: CGFloat?
     private var cachedHeight: CGFloat?
-    private var cachedContentVersion = -1
 
     override var allowsVibrancy: Bool { true }
 
@@ -37,7 +35,6 @@ final class CrawlBarMenuItemHostingView: NSView, CrawlBarMenuItemMeasuring, Craw
         self.highlightState = highlightState
         self.hostingController = NSHostingController(rootView: rootView)
         super.init(frame: .zero)
-        self.contentVersion = 1
         self.configureHostingView()
     }
 
@@ -56,7 +53,7 @@ final class CrawlBarMenuItemHostingView: NSView, CrawlBarMenuItemMeasuring, Craw
     }
 
     func measuredHeight(width: CGFloat) -> CGFloat {
-        if self.cachedWidth == width, self.cachedContentVersion == self.contentVersion, let cachedHeight {
+        if self.cachedWidth == width, let cachedHeight {
             return cachedHeight
         }
         if self.frame.size.width != width || self.bounds.size.width != width {
@@ -73,7 +70,6 @@ final class CrawlBarMenuItemHostingView: NSView, CrawlBarMenuItemMeasuring, Craw
         let rounded = ceil(safeHeight * scale) / scale
         self.cachedWidth = width
         self.cachedHeight = rounded
-        self.cachedContentVersion = self.contentVersion
         return rounded
     }
 
@@ -82,9 +78,7 @@ final class CrawlBarMenuItemHostingView: NSView, CrawlBarMenuItemMeasuring, Craw
         self.hostingController.view.autoresizingMask = [.width, .height]
         self.hostingController.view.frame = self.bounds
         self.addSubview(self.hostingController.view)
-        if #available(macOS 13.0, *) {
-            self.hostingController.sizingOptions = [.minSize, .intrinsicContentSize]
-        }
+        self.hostingController.sizingOptions = [.minSize, .intrinsicContentSize]
     }
 
     private func safeMeasuredHeight(from height: CGFloat) -> CGFloat {

--- a/Sources/CrawlBar/Menu/MenuModel.swift
+++ b/Sources/CrawlBar/Menu/MenuModel.swift
@@ -242,23 +242,6 @@ final class CrawlBarMenuModel: NSObject {
         return (immediate, commandInstallations)
     }
 
-    nonisolated private static func actionFailureStatus(_ result: CrawlCommandResult) -> CrawlAppStatus {
-        let fallback = "\(result.action) failed with exit \(result.exitCode)"
-        return CrawlAppStatus.commandFailure(
-            appID: result.appID,
-            action: result.action,
-            message: result.stderr.nilIfBlank ?? result.stdout.nilIfBlank,
-            fallback: fallback)
-    }
-
-    nonisolated private static func actionFailureStatus(appID: CrawlAppID, action: String, message: String) -> CrawlAppStatus {
-        CrawlAppStatus.commandFailure(
-            appID: appID,
-            action: action,
-            message: message,
-            fallback: "\(action) failed")
-    }
-
     nonisolated private static func actionFailureStatus(
         _ failure: CrawlAppStatus,
         refreshedStatus: CrawlAppStatus?,

--- a/Sources/CrawlBar/Settings/SettingsModelStatusActions.swift
+++ b/Sources/CrawlBar/Settings/SettingsModelStatusActions.swift
@@ -73,7 +73,7 @@ extension CrawlBarSettingsModel {
         let registry = self.registry
         Task.detached {
             let actionConfigValues = registry.executionConfigValues(for: installation)
-                let nativePublicationGuard = registry.nativePublicationGuard(for: installation, configValues: actionConfigValues, runner: runner)
+            let nativePublicationGuard = registry.nativePublicationGuard(for: installation, configValues: actionConfigValues, runner: runner)
             let message: String
             var actionError: CrawlAppStatus?
             var generation: UInt64?
@@ -94,9 +94,7 @@ extension CrawlBarSettingsModel {
                     })
                 generation = outcome.generation
                 for result in outcome.results { _ = try? logStore.save(result) }
-                message = outcome.failure == nil
-                    ? "\(Self.actionTitle(action)) finished"
-                    : outcome.failure!.summary
+                message = outcome.failure?.summary ?? "\(Self.actionTitle(action)) finished"
                 actionError = outcome.failure
             } catch CrawlActionCoordinatorError.busy {
                 await MainActor.run {
@@ -200,15 +198,6 @@ extension CrawlBarSettingsModel {
         default:
             action
         }
-    }
-
-    nonisolated static func actionFailureStatus(_ result: CrawlCommandResult) -> CrawlAppStatus {
-        let fallback = "\(result.action) failed with exit \(result.exitCode)"
-        return CrawlAppStatus.commandFailure(
-            appID: result.appID,
-            action: result.action,
-            message: result.stderr.nilIfBlank ?? result.stdout.nilIfBlank,
-            fallback: fallback)
     }
 
     nonisolated static func actionFailureStatus(appID: CrawlAppID, action: String, message: String) -> CrawlAppStatus {

--- a/Sources/CrawlBar/SharedUI/TextFormatters.swift
+++ b/Sources/CrawlBar/SharedUI/TextFormatters.swift
@@ -51,8 +51,8 @@ private final class CrawlBarLockedByteCountFormatter: @unchecked Sendable {
     }()
 
     func string(fromByteCount byteCount: Int64) -> String {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        return self.formatter.string(fromByteCount: byteCount)
+        self.lock.withLock {
+            self.formatter.string(fromByteCount: byteCount)
+        }
     }
 }

--- a/Sources/CrawlBarCLI/CLI.swift
+++ b/Sources/CrawlBarCLI/CLI.swift
@@ -234,7 +234,7 @@ enum CrawlBarCLI {
             installations = [installation]
         } else {
             installations = try registry.availableInstallations(includeSecrets: false)
-                .filter { Self.queryAction(for: $0, queryArguments: queryArguments) != nil }
+                .filter { CrawlQueryActionResolver.action(for: $0.manifest, queryArguments: queryArguments) != nil }
         }
         guard !installations.isEmpty else {
             throw CLIError.usage("no query-capable crawlers are enabled and on PATH")
@@ -288,14 +288,6 @@ enum CrawlBarCLI {
         if hasFailures, (!isAllApps || !hasSuccesses) {
             Foundation.exit(1)
         }
-    }
-
-    private static func queryAction(
-        for installation: CrawlAppInstallation,
-        queryArguments: [String])
-        -> String?
-    {
-        CrawlQueryActionResolver.action(for: installation.manifest, queryArguments: queryArguments)
     }
 
     private static func backup(

--- a/Sources/CrawlBarCLI/CLIModels.swift
+++ b/Sources/CrawlBarCLI/CLIModels.swift
@@ -60,7 +60,7 @@ struct CLIOptions {
     var positionals: [String] = []
 
     init(_ arguments: ArraySlice<String>) {
-        var iterator = Array(arguments).makeIterator()
+        var iterator = arguments.makeIterator()
         while let argument = iterator.next() {
             switch argument {
             case "--json":

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,7 +44,7 @@ crawlbar backup --app <id> [--json]
 crawlbar folder --app <id> [--json]
 ```
 
-Available actions come from each crawler manifest. `query` passes every argument after `--` to the crawler without shell expansion. `backup` copies the crawler's reported primary database into CrawlBar's backup location, and `folder` opens the reported data folder.
+Available actions come from each crawler manifest. `query` passes every argument after `--` to the crawler without shell expansion. `backup` creates SQLite snapshots of the crawler's reported local archive and cache databases in CrawlBar's backup location. `folder` prints the primary database's parent directory.
 
 Examples:
 


### PR DESCRIPTION
## What Problem This Solves

Old menu/settings implementations left unused image and failure helpers, a content-version counter that never changes, and a macOS availability branch below the app's minimum supported version.

## Why This Change Was Made

Remove those dead paths, simplify optional failure summaries and scoped formatter locking, and use the existing query resolver directly. Clarify that the CLI prints a database folder path and backs up reported SQLite archive/cache databases. UI layout, command behavior, and public APIs are preserved.

## User Impact

No intended visual or runtime change. Contributor-facing CLI documentation now matches existing behavior.

## Evidence

- Full build and executable self-test passed, retaining every test.
- Isolated Codex autoreview: scoped-clean at P0–P2.
- Packaged app signed with the OpenClaw Foundation Developer ID; signature verified. Synthetic isolated home, all built-ins disabled: Settings opens, the fixture displays Current and 42 messages, and Run Doctor completes. Before/after captures attached after inspection.

![Before: synthetic crawler settings](https://github.com/user-attachments/assets/13037bf6-35d0-4133-9bf3-b750589fc58e)

![After: synthetic crawler settings](https://github.com/user-attachments/assets/8277c7af-1f2c-42ec-abda-b671a4defd10)