### PR TITLE
build: support SwiftPM output layouts and pin CI toolchains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,50 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   swift:
-    runs-on: macos-15
+    name: Swift (Xcode ${{ matrix.xcode }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            xcode: '16.3'
+          - os: macos-26
+            xcode: '26.6'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Toolchain
+        run: |
+          xcodebuild -version
+          swift --version
       - name: Brand icon compatibility
         run: Scripts/check_brand_icons.sh
       - name: Build
-        run: swift build
+        run: |
+          swift build -Xswiftc -warnings-as-errors
+          printf 'CRAWLBAR_BIN_DIR=%s\n' "$(swift build --show-bin-path)" >> "$GITHUB_ENV"
       - name: Selftest
-        run: swift run crawlbar-selftest
+        run: '"$CRAWLBAR_BIN_DIR/crawlbar-selftest"'
       - name: CLI smoke
         run: |
-          swift run crawlbarctl apps --json
-          swift run crawlbarctl metadata --json
-          swift run crawlbarctl config validate
+          "$CRAWLBAR_BIN_DIR/crawlbarctl" apps --json
+          "$CRAWLBAR_BIN_DIR/crawlbarctl" metadata --json
+          "$CRAWLBAR_BIN_DIR/crawlbarctl" config validate
       - name: Package app
-        run: Scripts/package_app.sh
+        run: |
+          Scripts/package_app.sh
+          codesign --verify --deep --strict --verbose=2 dist/CrawlBar.app
       - name: Packaged brand icon compatibility
         run: Scripts/check_brand_icons.sh dist/CrawlBar.app
       - name: Packaged CLI smoke
@@ -34,3 +60,7 @@ jobs:
           dist/CrawlBar.app/Contents/Helpers/crawlbar apps --json
           dist/CrawlBar.app/Contents/Helpers/crawlbar metadata --json
           dist/CrawlBar.app/Contents/Helpers/crawlbar config validate
+      - name: Install CLI smoke
+        run: |
+          PREFIX="$RUNNER_TEMP/crawlbar-bin" Scripts/install_cli.sh
+          "$RUNNER_TEMP/crawlbar-bin/crawlbar" --help

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: [self-hosted, crabbox, openclaw, crawlbar, "${{ inputs.crabbox_runner_label }}"]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   verify:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Keep app packaging and CLI installation working with newer SwiftPM output layouts, and verify both Swift 6.1 and current stable Xcode builds in CI.
+
 ## 0.4.2 - 2026-09-11
 
 **Highlights:** More reliable publishing consent checks, safer archive backups, and bounded waits for stalled crawler commands.

--- a/Scripts/install_cli.sh
+++ b/Scripts/install_cli.sh
@@ -6,6 +6,7 @@ PREFIX="${PREFIX:-$HOME/.local/bin}"
 
 cd "$ROOT_DIR"
 swift build -c release --product crawlbarctl
+bin_dir="$(swift build -c release --show-bin-path)"
 mkdir -p "$PREFIX"
-install -m 0755 ".build/release/crawlbarctl" "$PREFIX/crawlbar"
+install -m 0755 "$bin_dir/crawlbarctl" "$PREFIX/crawlbar"
 echo "$PREFIX/crawlbar"

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -25,6 +25,7 @@ if [ "$official_release" = "1" ] && [ "$signing_identity" != "$EXPECTED_IDENTITY
 fi
 
 cd "$ROOT_DIR"
+trap 'rm -rf "$STAGING_APP_DIR" "$BUILD_DIR"' EXIT
 mkdir -p "$DIST_DIR"
 
 if [ "$universal_build" = "1" ]; then
@@ -40,18 +41,17 @@ if [ "$universal_build" = "1" ]; then
       --scratch-path "$BUILD_DIR/$arch" \
       --product crawlbarctl >&2
   done
-  arm_release="$BUILD_DIR/arm64/arm64-apple-macosx/release"
-  intel_release="$BUILD_DIR/x86_64/x86_64-apple-macosx/release"
+  arm_release="$(swift build -c release --triple arm64-apple-macosx14.0 --scratch-path "$BUILD_DIR/arm64" --show-bin-path)"
+  intel_release="$(swift build -c release --triple x86_64-apple-macosx14.0 --scratch-path "$BUILD_DIR/x86_64" --show-bin-path)"
   resource_bundle="$arm_release/CrawlBar_CrawlBar.bundle"
 else
   swift build -c release --product CrawlBar >&2
   swift build -c release --product crawlbarctl >&2
-  native_release="$ROOT_DIR/.build/release"
+  native_release="$(swift build -c release --show-bin-path)"
   resource_bundle="$native_release/CrawlBar_CrawlBar.bundle"
 fi
 
 rm -rf "$STAGING_APP_DIR"
-trap 'rm -rf "$STAGING_APP_DIR" "$BUILD_DIR"' EXIT
 mkdir -p "$MACOS_DIR" "$HELPERS_DIR" "$RESOURCES_DIR"
 
 if [ "$universal_build" = "1" ]; then

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,6 +14,8 @@ swift run crawlbarctl config validate
 
 SwiftPM names the development CLI `crawlbarctl` to avoid colliding with the `CrawlBar` app binary on case-insensitive macOS filesystems. Packaged and Homebrew installations expose the helper as `crawlbar`.
 
+CI runs the build, executable self-test, CLI smoke, and packaging checks with Xcode 16.3 on macOS 15 and Xcode 26.6 on macOS 26. Xcode 16.3 verifies the Swift 6.1 floor; the newer toolchain checks forward compatibility. Select a local Xcode with `DEVELOPER_DIR` when testing a specific compiler.
+
 ## Package the app
 
 ```sh
@@ -22,7 +24,7 @@ codesign --verify --deep --strict --verbose=2 dist/CrawlBar.app
 dist/CrawlBar.app/Contents/Helpers/crawlbar config validate
 ```
 
-The packaging script writes `dist/CrawlBar.app`. Local and CI packages use ad-hoc signing and do not need release credentials.
+The packaging script asks SwiftPM for its binary output directory, so both native SwiftPM and SwiftBuild layouts work. Set `CRAWLBAR_UNIVERSAL=1` to build both arm64 and x86_64 locally. The packaging script writes `dist/CrawlBar.app`. Local and CI packages use ad-hoc signing and do not need release credentials.
 
 ## Official artifacts
 


### PR DESCRIPTION
## What Problem This Solves

Packaging and CLI installation assume SwiftPM's old `.build/release` layout, so newer SwiftBuild toolchains build successfully but leave scripts looking in the wrong directory. CI also relies on a moving default Xcode and repeatedly asks SwiftPM to plan already-built smoke commands.

## Why This Change Was Made

Resolve native and universal product directories with `swift build --show-bin-path`, using the same configuration, target triple, and scratch path as the build. Register packaging cleanup before building. Pin checkout to v7.0.1's commit and run the full checks on Xcode 16.3/macOS 15 and Xcode 26.6/macOS 26. Invoke built binaries directly, verify packaged signatures, smoke-test CLI installation, and cancel superseded PR CI runs.

## User Impact

Local packaging and CLI installation work across SwiftPM build layouts. The Swift 6.1/macOS 14 minimum and all products remain unchanged.

## Evidence

- `actionlint`, `shellcheck -x Scripts/*.sh`, and `git diff --check` passed.
- Isolated Codex autoreview: scoped-clean at P0–P2.
- No Swift package dependencies exist. [checkout v7.0.1](https://github.com/actions/checkout/releases/tag/v7.0.1) was published July 20, safely beyond the 48-hour minimum; app-token v3.2.0 is already the latest stable release and remains pinned.
- The [macOS 15](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md) and [macOS 26](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md) inventories dated August 24 include both selected Xcodes.
- Clean local Swift 6.4 `swift build -j 4 -Xswiftc -warnings-as-errors` and all 53 executable self-tests passed.
- Native `Scripts/package_app.sh`, strict signature verification, and packaged icon checks passed without output-path symlinks. `PREFIX=<temporary directory> Scripts/install_cli.sh` passed. Both the packaged and installed helpers returned `current`, `Synthetic archive ready`, and 42 messages for an isolated synthetic crawler.
- Both [pinned CI compiler jobs](https://github.com/openclaw/crawlbar/actions/runs/34728247570) passed their complete build/test/package/install checks.
- `CRAWLBAR_UNIVERSAL=1 Scripts/package_app.sh` passed under Swift 6.4. `lipo -archs` reports `x86_64 arm64` for both app and helper; strict signature/icon checks passed, both app slices retain macOS 14.0, and the universal helper returned the same synthetic status. The discovered native directory is `.build/out/Products/Release`; `.build/release` does not exist.
- [CodeQL](https://github.com/openclaw/crawlbar/actions/runs/34728246144) passed on the same head as both compiler jobs.
