### PR TITLE
fix: preserve snapshots across repeated and colliding backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Preserve repeated and case-colliding archive backups, keep crawler IDs inside the backup root, and remove incomplete snapshots in private directories.
+- Compatibility: new backup directories add a random suffix and encode unusual crawler IDs to prevent collisions and path traversal; use the returned `directory` and `files` paths instead of constructing timestamp paths.
+
 - Keep app packaging and CLI installation working with newer SwiftPM output layouts, and verify both Swift 6.1 and current stable Xcode builds in CI.
 
 ## 0.4.2 - 2026-09-11

--- a/Sources/CrawlBarCore/DatabaseBackup.swift
+++ b/Sources/CrawlBarCore/DatabaseBackup.swift
@@ -66,7 +66,8 @@ public enum CrawlDatabaseBackupStore {
         status: CrawlAppStatus,
         root: URL,
         resolver: CrawlExecutableResolver,
-        sqliteProcessTimeout: TimeInterval)
+        sqliteProcessTimeout: TimeInterval,
+        now: Date = Date())
         throws -> CrawlDatabaseBackup
     {
         let resources = status.databases
@@ -84,15 +85,19 @@ public enum CrawlDatabaseBackupStore {
 
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
-        let timestamp = formatter.string(from: Date())
+        let timestamp = formatter.string(from: now)
             .replacingOccurrences(of: ":", with: "-")
-        let directory = root
-            .appendingPathComponent(status.appID.rawValue, isDirectory: true)
-            .appendingPathComponent(timestamp, isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let appDirectory = root.appendingPathComponent(Self.directoryComponent(status.appID), isDirectory: true)
+        try FileManager.default.createDirectory(at: appDirectory, withIntermediateDirectories: true)
+        let directory = appDirectory.appendingPathComponent("\(timestamp)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        var completed = false
+        defer {
+            if !completed { try? FileManager.default.removeItem(at: directory) }
+        }
 
         var copied: [String] = []
-        var usedNames: Set<String> = []
         let basenameCounts = Dictionary(grouping: resources, by: { $0.source.lastPathComponent })
             .mapValues(\.count)
         for entry in resources {
@@ -100,20 +105,25 @@ public enum CrawlDatabaseBackupStore {
                 for: entry.resource,
                 source: entry.source,
                 basenameCounts: basenameCounts,
-                usedNames: &usedNames)
+                directory: directory)
             let destination = directory.appendingPathComponent(destinationName)
-            if FileManager.default.fileExists(atPath: destination.path) {
-                try FileManager.default.removeItem(at: destination)
-            }
             try Self.backupSQLite(
                 source: entry.source,
                 destination: destination,
                 resolver: resolver,
                 timeoutSeconds: sqliteProcessTimeout)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destination.path)
             copied.append(destination.path)
         }
 
+        completed = true
         return CrawlDatabaseBackup(appID: status.appID, directory: directory.path, files: copied)
+    }
+
+    private static func directoryComponent(_ appID: CrawlAppID) -> String {
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
+        let encoded = appID.rawValue.addingPercentEncoding(withAllowedCharacters: allowed) ?? ""
+        return encoded.isEmpty ? "%" : encoded
     }
 
     private static func backupSQLite(
@@ -155,7 +165,7 @@ public enum CrawlDatabaseBackupStore {
         for resource: CrawlDatabaseResource,
         source: URL,
         basenameCounts: [String: Int],
-        usedNames: inout Set<String>)
+        directory: URL)
         -> String
     {
         let basename = source.lastPathComponent
@@ -163,11 +173,11 @@ public enum CrawlDatabaseBackupStore {
         let prefix = Self.safeFilename(resource.label.nilIfBlank ?? resource.id)
         var candidate = shouldPrefix ? "\(prefix)-\(basename)" : basename
         var suffix = 2
-        while usedNames.contains(candidate) {
+        // The destination filesystem decides whether case or Unicode spellings collide.
+        while FileManager.default.fileExists(atPath: directory.appendingPathComponent(candidate).path) {
             candidate = "\(prefix)-\(suffix)-\(basename)"
             suffix += 1
         }
-        usedNames.insert(candidate)
         return candidate
     }
 

--- a/Sources/CrawlBarSelfTest/SelfTest.swift
+++ b/Sources/CrawlBarSelfTest/SelfTest.swift
@@ -48,6 +48,7 @@ enum CrawlBarSelfTest {
         try Self.testInstallerTimesOutWedgedBrew()
         try Self.testTimeoutTeardownUsesProcessWait()
         try Self.testDatabaseBackupCopiesFiles()
+        try Self.testBackupIsolation()
         try Self.testDatabaseBackupTimesOutWedgedSqlite()
         try Self.testRedactorScrubsSecrets()
         print("crawlbar selftest ok")

--- a/Sources/CrawlBarSelfTest/SelfTestBackupIsolation.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestBackupIsolation.swift
@@ -1,0 +1,69 @@
+import CrawlBarCore
+import Foundation
+
+extension CrawlBarSelfTest {
+    static func testBackupIsolation() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crawlbar-backup-isolation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let root = directory.appendingPathComponent("backups", isDirectory: true)
+        let firstSource = directory.appendingPathComponent("first.db")
+        try Self.createSQLiteDatabase(firstSource, value: "original")
+        let resource = CrawlDatabaseResource(id: "first", label: "First", kind: .sqlite, path: firstSource.path)
+        let now = Date(timeIntervalSince1970: 1_775_000_000)
+        func backup(_ id: String, _ resources: [CrawlDatabaseResource]) throws -> CrawlDatabaseBackup {
+            try CrawlDatabaseBackupStore.backup(
+                status: CrawlAppStatus(appID: CrawlAppID(rawValue: id), state: .current, summary: "Fixture", databases: resources),
+                root: root, resolver: CrawlExecutableResolver(), sqliteProcessTimeout: 5, now: now)
+        }
+
+        let first = try backup("repeated", [resource])
+        try Self.runSQLite(firstSource, sql: "update sample set value = 'updated';")
+        let second = try backup("repeated", [resource])
+        try Self.expect(first.directory != second.directory, "backups at the same instant have separate directories")
+        try Self.expect(try Self.sqliteValue(URL(fileURLWithPath: first.files[0])) == "original", "later backups preserve earlier snapshots")
+        try Self.expect(try Self.sqliteValue(URL(fileURLWithPath: second.files[0])) == "updated", "new backups contain current source data")
+
+        for id in ["../escaped", "..", "/absolute", "", "percent%/id"] {
+            let result = try backup(id, [resource])
+            let path = URL(fileURLWithPath: result.directory).standardizedFileURL.path
+            try Self.expect(path.hasPrefix(root.standardizedFileURL.path + "/"), "crawler identifiers cannot escape the backup root")
+            let directoryAttributes = try FileManager.default.attributesOfItem(atPath: result.directory)
+            let fileAttributes = try FileManager.default.attributesOfItem(atPath: result.files[0])
+            try Self.expect((directoryAttributes[.posixPermissions] as? NSNumber)?.intValue == 0o700, "backup directories are private")
+            try Self.expect((fileAttributes[.posixPermissions] as? NSNumber)?.intValue == 0o600, "backup files are private")
+        }
+
+        let upperDirectory = directory.appendingPathComponent("upper", isDirectory: true)
+        let lowerDirectory = directory.appendingPathComponent("lower", isDirectory: true)
+        try FileManager.default.createDirectory(at: upperDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: lowerDirectory, withIntermediateDirectories: true)
+        let upper = upperDirectory.appendingPathComponent("Archive.db")
+        let lower = lowerDirectory.appendingPathComponent("archive.db")
+        try Self.createSQLiteDatabase(upper, value: "upper")
+        try Self.createSQLiteDatabase(lower, value: "lower")
+        let caseResult = try backup("case", [
+            CrawlDatabaseResource(id: "upper", label: "Upper", kind: .sqlite, path: upper.path),
+            CrawlDatabaseResource(id: "lower", label: "Lower", kind: .sqlite, path: lower.path),
+        ])
+        let caseValues = try caseResult.files.map { try Self.sqliteValue(URL(fileURLWithPath: $0)) }
+        try Self.expect(caseValues == ["upper", "lower"], "case-only names preserve both archives on the destination filesystem")
+
+        let invalid = directory.appendingPathComponent("invalid.db")
+        try Data("not a SQLite database".utf8).write(to: invalid)
+        do {
+            _ = try backup("repeated", [resource, CrawlDatabaseResource(id: "bad", label: "Bad", kind: .sqlite, path: invalid.path)])
+            throw SelfTestError.failed("invalid SQLite input must fail backup")
+        } catch CrawlDatabaseBackupError.sqliteBackupFailed {
+            let remaining = try FileManager.default.contentsOfDirectory(
+                at: root.appendingPathComponent("repeated"), includingPropertiesForKeys: nil)
+            let remainingPaths = Set(remaining.map { $0.resolvingSymlinksInPath().path })
+            let completedPaths = Set([first.directory, second.directory].map {
+                URL(fileURLWithPath: $0).resolvingSymlinksInPath().path
+            })
+            try Self.expect(remainingPaths == completedPaths, "failed backups remove only their partial directory")
+            try Self.expect(try Self.sqliteValue(URL(fileURLWithPath: first.files[0])) == "original", "failed backups preserve completed snapshots")
+        }
+    }
+}

--- a/Sources/CrawlBarSelfTest/SelfTestNativeSafety.swift
+++ b/Sources/CrawlBarSelfTest/SelfTestNativeSafety.swift
@@ -9,7 +9,7 @@ extension CrawlBarSelfTest {
         let source = directory.appendingPathComponent("source.db")
         let archive = directory.appendingPathComponent("archive.db")
         try Data("synthetic source".utf8).write(to: source)
-        try Data("synthetic archive".utf8).write(to: archive)
+        try Self.createSQLiteDatabase(archive, value: "synthetic archive")
         let payload: [String: Any] = [
             "schema_version": "crawlkit.control.v1", "state": "ok",
             "source": ["database_path": source.path, "database_bytes": 999],
@@ -25,13 +25,14 @@ extension CrawlBarSelfTest {
         let capture = directory.appendingPathComponent("backup-source.txt")
         let sqlite = directory.appendingPathComponent("sqlite3")
         let quoted = "'" + capture.path.replacingOccurrences(of: "'", with: "'\\''") + "'"
-        try Data("#!/bin/sh\nprintf '%s' \"$1\" > \(quoted)\ncat >/dev/null\n".utf8).write(to: sqlite)
+        try Data("#!/bin/sh\nprintf '%s' \"$1\" > \(quoted)\nexec /usr/bin/sqlite3 \"$@\"\n".utf8).write(to: sqlite)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: sqlite.path)
         let resolver = CrawlExecutableResolver(environment: ["HOME": directory.path, "PATH": directory.path + ":/usr/bin:/bin"])
         let backup = try CrawlDatabaseBackupStore.backup(
             status: status, root: directory.appendingPathComponent("backups"),
             resolver: resolver, sqliteProcessTimeout: 5)
         try Self.expect(backup.files.count == 1, "backup selects one archive resource")
+        try Self.expect(try Self.sqliteValue(URL(fileURLWithPath: backup.files[0])) == "synthetic archive", "backup creates a usable archive snapshot")
         let selected = try String(contentsOf: capture, encoding: .utf8)
         try Self.expect(selected == archive.path, "actual backup invocation never receives the source database")
         let sourceBytes = try Data(contentsOf: source)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,6 +46,8 @@ crawlbar folder --app <id> [--json]
 
 Available actions come from each crawler manifest. `query` passes every argument after `--` to the crawler without shell expansion. `backup` creates SQLite snapshots of the crawler's reported local archive and cache databases in CrawlBar's backup location. `folder` prints the primary database's parent directory.
 
+Backups use unique private directories and preserve completed snapshots when a later backup fails. Treat returned backup paths as opaque; directory names may include encoded crawler IDs and a random suffix.
+
 Examples:
 
 ```sh


### PR DESCRIPTION
## What Problem This Solves

Backups taken within one second could overwrite an earlier snapshot. Archive filenames differing only by case could overwrite each other on the destination filesystem. Unusual crawler IDs could escape the backup root, and failed multi-database runs left partial snapshots.

## User Impact

Each backup preserves previous snapshots and every selected archive, uses private directories/files, and removes its own incomplete output on failure. Compatibility: new directory names include a random suffix and encode unusual crawler IDs; callers should use the returned `directory` and `files` paths.

## Why This Change Was Made

Allocate an exclusive directory per operation, choose filenames against the actual destination filesystem, and keep cleanup scoped to that directory. Archive selection remains unchanged. The regression suite fixes time explicitly and checks completed snapshot contents, path containment, case collisions, permissions, and failure cleanup.

## Evidence

- Full warnings-as-errors build and all 54 executable self-tests passed.
- Built CLI `backup --app <synthetic-id> --json`, real SQLite fixtures, before/after:

| Check | Before | After |
| --- | --- | --- |
| Repeated backup directories | reused | unique |
| First snapshot contents | overwritten | preserved |
| `../` crawler ID | escaped backup root | contained |
| Case-only archive filenames | one archive overwritten | both preserved |
| Failed multi-database backup | partial directory remained | partial directory removed |
| Directory/file permissions | 0755/0644 | 0700/0600 |

- The existing iMessage source-selection fixture now records the source and runs real SQLite, retaining all its assertions and verifying a usable archive snapshot. No tests were removed or weakened.
- Isolated Codex autoreview at P0–P2: scoped-clean.

- Combined backup/CLI candidate: the final packaged helper passes both the CLI contract suite and every backup preservation/containment/permission check; strict signature and icon checks pass.
