### PR TITLE
fix: honor crawler configuration and reject incomplete CLI options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
           "$CRAWLBAR_BIN_DIR/crawlbarctl" apps --json
           "$CRAWLBAR_BIN_DIR/crawlbarctl" metadata --json
           "$CRAWLBAR_BIN_DIR/crawlbarctl" config validate
+      - name: CLI contracts
+        run: python3 Scripts/test_cli.py "$CRAWLBAR_BIN_DIR/crawlbarctl"
       - name: Package app
         run: |
           Scripts/package_app.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Keep app packaging and CLI installation working with newer SwiftPM output layouts, and verify both Swift 6.1 and current stable Xcode builds in CI.
+- Pass native credentials to CLI queries, configure newly discovered crawlers without prior registration, and reject missing option values before running commands.
+- Compatibility: values starting with `--` now use `--option=value` syntax, preventing a missing value from consuming the next flag and changing configuration unintentionally.
 
 ## 0.4.2 - 2026-09-11
 

--- a/Scripts/test_cli.py
+++ b/Scripts/test_cli.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Exercise crawler CLI contracts with a synthetic home and no saved credentials."""
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    binary = str(Path(sys.argv[1]).resolve())
+    failures = []
+
+    def expect(condition, message):
+        if not condition:
+            failures.append(message)
+
+    with tempfile.TemporaryDirectory(prefix="crawlbar-cli-test-") as temporary:
+        home = Path(temporary)
+        manifests = home / "manifests"
+        manifests.mkdir()
+        config_path = home / ".crawlbar/config.json"
+        config_path.parent.mkdir()
+        native = home / "fixture.toml"
+        credential = "opaque-fixture-value"
+        native.write_text('[auth]\ncredential = "' + credential + '"\n[settings]\nlabel = "original"\n')
+        crawler = home / "fixturecrawl"
+        crawler.write_text(
+            '#!/bin/sh\n'
+            'if [ "$1" = status ]; then\n'
+            '  printf \'%s\\n\' \'{"state":"current","summary":"Fixture ready"}\'\n'
+            '  exit 0\n'
+            'fi\n'
+            'if [ "$1" = query ] && [ "$2" != needle ]; then exit 42; fi\n'
+            'if [ "$FIXTURE_CREDENTIAL" != "opaque-fixture-value" ]; then\n'
+            '  echo "fixture credential missing" >&2\n'
+            '  exit 41\n'
+            'fi\n'
+            'printf \'%s\\n\' "$FIXTURE_CREDENTIAL"\n'
+        )
+        crawler.chmod(0o755)
+        manifest = {
+            "id": "fixture", "display_name": "Fixture", "binary": {"name": str(crawler)},
+            "paths": {"default_config": str(native)},
+            "commands": {"status": ["status"], "doctor": ["doctor"], "query": ["query"]},
+            "capabilities": ["status", "doctor", "search"],
+            "config_options": [
+                {"id": "credential", "kind": "secret", "env_var": "FIXTURE_CREDENTIAL", "config_key": "auth.credential"},
+                {"id": "label", "config_key": "settings.label"},
+            ],
+        }
+        (manifests / "fixture.json").write_text(json.dumps(manifest))
+        config = {"version": 3, "manifest_directories": [str(manifests)], "apps": []}
+        config_path.write_text(json.dumps(config))
+        environment = {"PATH": "/usr/bin:/bin", "CFFIXED_USER_HOME": str(home)}
+
+        def run(*arguments):
+            return subprocess.run([binary, *arguments], env=environment, capture_output=True, text=True, timeout=15)
+
+        # Refuse all writes unless Foundation is using the disposable home.
+        if run("config", "path").stdout.strip() != str(config_path):
+            raise RuntimeError("CLI did not select the isolated configuration")
+        metadata = run("metadata", "--json")
+        metadata.check_returncode()
+        config["apps"] = [
+            {"id": row["id"], "enabled": False, "show_in_menu_bar": False}
+            for row in json.loads(metadata.stdout) if row["id"] != "fixture"
+        ]
+        config_path.write_text(json.dumps(config))
+
+        query = run("query", "--app", "fixture", "--json", "--", "needle")
+        expect(query.returncode == 0, "query loads native execution credentials")
+        expect(credential not in query.stdout + query.stderr, "query output redacts injected credentials")
+        if query.returncode == 0:
+            expect("[REDACTED]" in json.loads(query.stdout)[0]["stdout"], "query preserves redacted command output")
+        doctor = run("doctor", "--app", "fixture", "--json")
+        expect(doctor.returncode == 0 and credential not in doctor.stdout, "ordinary actions retain credential handling")
+
+        updated = run("config", "set", "--app", "fixture", "--key", "label", "--value", "changed")
+        expect(updated.returncode == 0, "config set accepts discovered crawlers without a saved app row")
+        value = run("config", "get", "--app", "fixture", "--key", "label", "--json")
+        expect(value.returncode == 0 and json.loads(value.stdout)[0].get("value") == "changed", "custom crawler configuration round-trips")
+        literal = run("config", "set", "--app=fixture", "--key=label", "--value=--json")
+        expect(literal.returncode == 0, "attached option values preserve flag-like text")
+        literal_value = run("config", "get", "--app", "fixture", "--key", "label", "--json")
+        expect(literal_value.returncode == 0 and json.loads(literal_value.stdout)[0].get("value") == "--json",
+               "flag-like configuration values round-trip")
+        cleared = run("config", "set", "--app", "fixture", "--key", "label", "--value", "")
+        expect(cleared.returncode == 0, "an explicitly empty value still clears configuration")
+        empty = run("config", "get", "--app", "fixture", "--key", "label", "--json")
+        expect(empty.returncode == 0 and json.loads(empty.stdout)[0].get("value") is None, "cleared values are removed")
+        expect(credential in native.read_text(), "editing nonsecret values preserves native credentials")
+        expect(credential not in config_path.read_text(), "native credentials stay out of main configuration")
+
+        for arguments in [
+            ("status", "--app"),
+            ("config", "get", "--app", "fixture", "--key"),
+            ("dev", "register", "--app", "fixture", "--binary"),
+            ("config", "set", "--app", "fixture", "--key", "label", "--value"),
+        ]:
+            for suffix in [(), ("--json",)]:
+                result = run(*arguments, *suffix)
+                expect(result.returncode != 0 and not result.stdout and "requires a value" in result.stderr,
+                       "missing option values fail before command execution: " + arguments[-1] + str(suffix))
+
+        persisted = json.loads(config_path.read_text())
+        persisted["apps"].append({"id": "orphan", "config_values": {"label": "old"}})
+        config_path.write_text(json.dumps(persisted))
+        orphan = run("config", "set", "--app", "orphan", "--key", "label", "--value", "kept")
+        expect(orphan.returncode == 0, "existing orphaned configuration remains editable")
+        saved = json.loads(config_path.read_text())
+        expect(next(row for row in saved["apps"] if row["id"] == "orphan")["config_values"]["label"] == "kept",
+               "orphaned configuration updates persist")
+        unknown = run("config", "set", "--app", "unknown", "--key", "label", "--value", "invalid")
+        expect(unknown.returncode != 0, "unknown crawlers still fail configuration writes")
+
+    for failure in failures:
+        print("FAIL: " + failure, file=sys.stderr)
+    if failures:
+        return 1
+    print("crawlbar CLI contracts ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Sources/CrawlBarCLI/CLI.swift
+++ b/Sources/CrawlBarCLI/CLI.swift
@@ -18,7 +18,7 @@ enum CrawlBarCLI {
             return
         }
 
-        let options = CLIOptions(arguments.dropFirst())
+        let options = try CLIOptions(arguments.dropFirst())
         let registry = CrawlAppRegistry()
         let runner = CrawlCommandRunner()
         let statusService = CrawlStatusService(runner: runner)
@@ -163,11 +163,9 @@ enum CrawlBarCLI {
         guard installation.binaryPath != nil else {
             throw CLIError.usage("\(installation.manifest.binary.name) is not on PATH")
         }
-        let result = try runner.run(
-            installation: installation,
-            configValues: registry.executionConfigValues(for: installation),
-            action: action,
-            timeoutSeconds: 600)
+        let result = try Self.runCommand(
+            installation: installation, action: action,
+            registry: registry, runner: runner, timeoutSeconds: 600)
         _ = try? CrawlActionLogStore().save(result)
         if json {
             try CLIOutput.writeJSON(result)
@@ -180,6 +178,23 @@ enum CrawlBarCLI {
         if !result.succeeded {
             Foundation.exit(Int32(result.exitCode))
         }
+    }
+
+    static func runCommand(
+        installation: CrawlAppInstallation,
+        action: String,
+        registry: CrawlAppRegistry,
+        runner: CrawlCommandRunner,
+        extraArguments: [String] = [],
+        timeoutSeconds: TimeInterval)
+        throws -> CrawlCommandResult
+    {
+        try runner.run(
+            installation: installation,
+            configValues: registry.executionConfigValues(for: installation),
+            action: action,
+            extraArguments: extraArguments,
+            timeoutSeconds: timeoutSeconds)
     }
 
     private static func install(
@@ -207,86 +222,6 @@ enum CrawlBarCLI {
         print(result.stdout.nilIfBlank ?? result.stderr.nilIfBlank ?? "installed \(installation.manifest.binary.name)")
         if !result.succeeded {
             Foundation.exit(Int32(result.exitCode))
-        }
-    }
-
-    private static func query(registry: CrawlAppRegistry, runner: CrawlCommandRunner, options: CLIOptions) throws {
-        let queryArguments = options.positionals
-        guard !queryArguments.isEmpty else {
-            throw CLIError.usage("query requires text or SQL")
-        }
-
-        let isAllApps = options.appID == nil || options.appID == CrawlAppID(rawValue: "all")
-        let installations: [CrawlAppInstallation]
-        if !isAllApps, let appID = options.appID {
-            guard let installation = try registry.installation(for: appID, includeSecrets: false) else {
-                throw CLIError.usage("unknown app: \(appID.rawValue)")
-            }
-            guard installation.manifest.availability == .available else {
-                throw CLIError.usage("\(installation.manifest.displayName) is coming soon")
-            }
-            guard installation.enabled else {
-                throw CLIError.usage("\(appID.rawValue) is disabled")
-            }
-            guard installation.binaryPath != nil else {
-                throw CLIError.usage("\(installation.manifest.binary.name) is not on PATH")
-            }
-            installations = [installation]
-        } else {
-            installations = try registry.availableInstallations(includeSecrets: false)
-                .filter { CrawlQueryActionResolver.action(for: $0.manifest, queryArguments: queryArguments) != nil }
-        }
-        guard !installations.isEmpty else {
-            throw CLIError.usage("no query-capable crawlers are enabled and on PATH")
-        }
-
-        let results = installations.map { installation -> CrawlCommandResult in
-            guard let action = CrawlQueryActionResolver.action(
-                for: installation.manifest,
-                queryArguments: queryArguments)
-            else {
-                return CrawlCommandResult(
-                    appID: installation.id,
-                    action: "query",
-                    exitCode: 64,
-                    stdout: "",
-                    stderr: "\(installation.id.rawValue) does not expose a query command",
-                    startedAt: Date(),
-                    finishedAt: Date())
-            }
-            do {
-                return try runner.run(
-                    installation: installation,
-                    action: action,
-                    extraArguments: queryArguments,
-                    timeoutSeconds: 120)
-            } catch {
-                return CrawlCommandResult(
-                    appID: installation.id,
-                    action: action,
-                    exitCode: 1,
-                    stdout: "",
-                    stderr: error.localizedDescription,
-                    startedAt: Date(),
-                    finishedAt: Date())
-            }
-        }
-
-        if options.json {
-            try CLIOutput.writeJSON(results)
-        } else if results.count == 1, let result = results.first {
-            print(result.stdout.nilIfBlank ?? result.stderr.nilIfBlank ?? "exit \(result.exitCode)")
-        } else {
-            for result in results {
-                print("== \(result.appID.rawValue) ==")
-                print(result.stdout.nilIfBlank ?? result.stderr.nilIfBlank ?? "exit \(result.exitCode)")
-            }
-        }
-
-        let hasFailures = results.contains { !$0.succeeded }
-        let hasSuccesses = results.contains { $0.succeeded }
-        if hasFailures, (!isAllApps || !hasSuccesses) {
-            Foundation.exit(1)
         }
     }
 

--- a/Sources/CrawlBarCLI/CLIConfigCommands.swift
+++ b/Sources/CrawlBarCLI/CLIConfigCommands.swift
@@ -83,9 +83,10 @@ extension CrawlBarCLI {
             throw CLIError.usage("config set requires --value <value>")
         }
         var config = try store.loadOrCreateDefault()
-        guard let index = config.apps.firstIndex(where: { $0.id == appID }) else {
+        if config.appConfig(for: appID) == nil, try registry.installation(for: appID) == nil {
             throw CLIError.usage("unknown app: \(appID.rawValue)")
         }
+        let index = Self.ensureAppConfig(appID: appID, in: &config)
         if value.nilIfBlank == nil {
             config.apps[index].configValues.removeValue(forKey: key)
         } else {

--- a/Sources/CrawlBarCLI/CLIDevCommands.swift
+++ b/Sources/CrawlBarCLI/CLIDevCommands.swift
@@ -104,7 +104,7 @@ extension CrawlBarCLI {
         return value
     }
 
-    private static func ensureAppConfig(appID: CrawlAppID, in config: inout CrawlBarConfig) -> Int {
+    static func ensureAppConfig(appID: CrawlAppID, in config: inout CrawlBarConfig) -> Int {
         if let index = config.apps.firstIndex(where: { $0.id == appID }) {
             return index
         }

--- a/Sources/CrawlBarCLI/CLIModels.swift
+++ b/Sources/CrawlBarCLI/CLIModels.swift
@@ -59,27 +59,35 @@ struct CLIOptions {
     var diagnostics = false
     var positionals: [String] = []
 
-    init(_ arguments: ArraySlice<String>) {
+    init(_ arguments: ArraySlice<String>) throws {
         var iterator = arguments.makeIterator()
+        func requiredValue(for option: String, attached: String?) throws -> String {
+            if let attached { return attached }
+            guard let value = iterator.next(), !value.hasPrefix("--") else {
+                throw CLIError.usage("\(option) requires a value; use \(option)=<value> for values starting with --")
+            }
+            return value
+        }
         while let argument = iterator.next() {
-            switch argument {
-            case "--json":
+            let separator = argument.firstIndex(of: "=")
+            let option = separator.map { String(argument[..<$0]) } ?? argument
+            let attached = separator.map { String(argument[argument.index(after: $0)...]) }
+            switch option {
+            case "--json" where attached == nil:
                 self.json = true
             case "--app":
-                if let value = iterator.next() {
-                    self.appID = CrawlAppID(rawValue: value)
-                }
+                self.appID = CrawlAppID(rawValue: try requiredValue(for: option, attached: attached))
             case "--binary":
-                self.binary = iterator.next()
+                self.binary = try requiredValue(for: option, attached: attached)
             case "--key":
-                self.key = iterator.next()
+                self.key = try requiredValue(for: option, attached: attached)
             case "--value":
-                self.value = iterator.next()
-            case "--reveal":
+                self.value = try requiredValue(for: option, attached: attached)
+            case "--reveal" where attached == nil:
                 self.revealSecrets = true
-            case "--diagnostics":
+            case "--diagnostics" where attached == nil:
                 self.diagnostics = true
-            case "--":
+            case "--" where attached == nil:
                 while let value = iterator.next() {
                     self.positionals.append(value)
                 }

--- a/Sources/CrawlBarCLI/CLIQueryCommands.swift
+++ b/Sources/CrawlBarCLI/CLIQueryCommands.swift
@@ -1,0 +1,86 @@
+import CrawlBarCore
+import Foundation
+
+extension CrawlBarCLI {
+    static func query(registry: CrawlAppRegistry, runner: CrawlCommandRunner, options: CLIOptions) throws {
+        let queryArguments = options.positionals
+        guard !queryArguments.isEmpty else {
+            throw CLIError.usage("query requires text or SQL")
+        }
+
+        let isAllApps = options.appID == nil || options.appID == CrawlAppID(rawValue: "all")
+        let installations: [CrawlAppInstallation]
+        if !isAllApps, let appID = options.appID {
+            guard let installation = try registry.installation(for: appID, includeSecrets: false) else {
+                throw CLIError.usage("unknown app: \(appID.rawValue)")
+            }
+            guard installation.manifest.availability == .available else {
+                throw CLIError.usage("\(installation.manifest.displayName) is coming soon")
+            }
+            guard installation.enabled else {
+                throw CLIError.usage("\(appID.rawValue) is disabled")
+            }
+            guard installation.binaryPath != nil else {
+                throw CLIError.usage("\(installation.manifest.binary.name) is not on PATH")
+            }
+            installations = [installation]
+        } else {
+            installations = try registry.availableInstallations(includeSecrets: false)
+                .filter { CrawlQueryActionResolver.action(for: $0.manifest, queryArguments: queryArguments) != nil }
+        }
+        guard !installations.isEmpty else {
+            throw CLIError.usage("no query-capable crawlers are enabled and on PATH")
+        }
+
+        let results = installations.map { installation -> CrawlCommandResult in
+            guard let action = CrawlQueryActionResolver.action(
+                for: installation.manifest,
+                queryArguments: queryArguments)
+            else {
+                return CrawlCommandResult(
+                    appID: installation.id,
+                    action: "query",
+                    exitCode: 64,
+                    stdout: "",
+                    stderr: "\(installation.id.rawValue) does not expose a query command",
+                    startedAt: Date(),
+                    finishedAt: Date())
+            }
+            do {
+                return try Self.runCommand(
+                    installation: installation,
+                    action: action,
+                    registry: registry,
+                    runner: runner,
+                    extraArguments: queryArguments,
+                    timeoutSeconds: 120)
+            } catch {
+                return CrawlCommandResult(
+                    appID: installation.id,
+                    action: action,
+                    exitCode: 1,
+                    stdout: "",
+                    stderr: error.localizedDescription,
+                    startedAt: Date(),
+                    finishedAt: Date())
+            }
+        }
+
+        if options.json {
+            try CLIOutput.writeJSON(results)
+        } else if results.count == 1, let result = results.first {
+            print(result.stdout.nilIfBlank ?? result.stderr.nilIfBlank ?? "exit \(result.exitCode)")
+        } else {
+            for result in results {
+                print("== \(result.appID.rawValue) ==")
+                print(result.stdout.nilIfBlank ?? result.stderr.nilIfBlank ?? "exit \(result.exitCode)")
+            }
+        }
+
+        let hasFailures = results.contains { !$0.succeeded }
+        let hasSuccesses = results.contains { $0.succeeded }
+        if hasFailures, (!isAllApps || !hasSuccesses) {
+            Foundation.exit(1)
+        }
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,7 +68,9 @@ crawlbar config set --app <id> --key <id> --value <value> [--json]
 
 The main configuration file is `~/.crawlbar/config.json`. External manifests live under `~/.crawlbar/apps`, and redacted action logs live under `~/.crawlbar/logs`.
 
-Secret configuration values are hidden by default. Use `--reveal` only in a private terminal when the raw value is explicitly required.
+Discovered external crawlers can be configured immediately; `config set` creates their saved app entry when needed. Flags that take values reject a missing value or a following flag. Use `--value=--literal` (or the corresponding `--app=`, `--key=`, or `--binary=` form) when a value begins with `--`. An explicitly empty `--value` still clears a setting.
+
+Queries and actions resolve execution credentials separately from displayed installation metadata and redact those credentials from command output. Secret configuration values are hidden by default. Use `--reveal` only in a private terminal when the raw value is explicitly required.
 
 ## Development binary overrides
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,6 +10,7 @@ swift run crawlbar-selftest
 swift run crawlbarctl apps --json
 swift run crawlbarctl metadata --json
 swift run crawlbarctl config validate
+python3 Scripts/test_cli.py "$(swift build --show-bin-path)/crawlbarctl"
 ```
 
 SwiftPM names the development CLI `crawlbarctl` to avoid colliding with the `CrawlBar` app binary on case-insensitive macOS filesystems. Packaged and Homebrew installations expose the helper as `crawlbar`.


### PR DESCRIPTION
## What Problem This Solves

CLI queries could fail despite valid native crawler credentials, and `config set` rejected discovered crawlers until another command created their saved row. A missing option value could silently broaden a status request or consume the next flag as configuration data.

## User Impact

Queries use the same execution credentials and redaction as actions, discovered crawlers can be configured immediately, and incomplete options fail before execution. Compatibility: values beginning with `--` use `--option=value` syntax; explicitly empty and ordinary negative values remain supported.

## Why This Change Was Made

Give CLI command execution one credential-resolution path, reuse app-row creation for configuration writes, and separate query orchestration from command dispatch. Keep existing orphaned configuration editable. A black-box suite creates a synthetic home, verifies isolation before writes, disables built-in crawlers, and runs the real CLI without saved credentials.

Maintainer compatibility decision: accept the attached-value requirement for text beginning with `--`. The old parser can turn an omitted value into a successful configuration write; the reproduced case saved `--json`. The new parser returns an error and preserves the original value, while `--value=--json` still stores that literal text. The migration is documented in the CLI reference and changelog.

## Evidence

- Built CLI reproduction on the previous version failed native-credential queries, discovered-crawler configuration, and missing-value cases.
- Updated built CLI: `python3 Scripts/test_cli.py <crawlbarctl>` reports `crawlbar CLI contracts ok`. It covers credentials/redaction, query arguments, native/main config persistence, clearing values, attached flag-like values, missing values at end/followed by another flag, and orphan/unknown crawler behavior.
- Warnings-as-errors CLI build and actionlint passed. CI runs the new suite on both pinned Xcodes alongside every existing self-test and packaging check.
- Isolated Codex autoreview at P0–P2: scoped-clean. The earlier following-option finding is addressed with attached-value syntax and explicit compatibility documentation.

- Combined backup/CLI candidate: all 54 self-tests pass. The final packaged helper passes the CLI contracts and real-SQLite backup proof; strict signature and icon checks pass.
